### PR TITLE
Add aca_dark package

### DIFF
--- a/mica/aca_dark/__init__.py
+++ b/mica/aca_dark/__init__.py
@@ -1,0 +1,2 @@
+from dark_cal import *
+from dark_model import *

--- a/mica/aca_dark/dark_cal.py
+++ b/mica/aca_dark/dark_cal.py
@@ -1,0 +1,31 @@
+__all__ = ['get_dark_cal_image', 'get_dark_cal_properties']
+
+
+def get_dark_cal_image(date, before_date=False):
+    """
+    Return the dark calibration image (e-/s) nearest to ``date``.
+
+    If ``before_date`` is True (default) then use the first calibration which
+    occurs before ``date``.
+
+    :param date: date in any DateTime format
+    :param before_date: use first cal before date
+
+    :returns: 1024 x 1024 ndarray with dark cal image in e-/s
+    """
+    raise NotImplementedError()
+
+
+def get_dark_cal_properties(start=None, stop=None, include_images=False):
+    """
+    Return a table of dark calibration properties between ``start`` and ``stop``.
+
+    If ``include_images`` is True then an additional column ``dark_image`` is
+    defined which contains the corresponding 1024x1024 dark cal image.
+
+    :param start: Start time (default=beginning of mission)
+    :param stop: Stop time (default=now)
+
+    :returns: astropy Table of dark calibration properties
+    """
+    raise NotImplementedError()

--- a/mica/aca_dark/dark_model.py
+++ b/mica/aca_dark/dark_model.py
@@ -1,0 +1,51 @@
+__all__ = ['get_dark_model']
+
+
+def get_dark_model(date, t_ccd):
+    """
+    Return the dark current model corresponding to ``date`` and ``t_ccd``.
+
+    :param date: date in any DateTime format
+    :param t_ccd: CCD temperature (deg C)
+
+    :returns: TBD
+    """
+    raise NotImplementedError()
+
+
+def get_acq_success(date, t_ccd, mag):
+    """
+    Return probability of acquisition success for given date, temperature and mag.
+
+    Any of the inputs can be scalars or arrays, with the output being the result of
+    the broadcasted dimension of the inputs.
+
+    This is based on the dark model and acquisition success fitting presented
+    in the State of the ACA 2013 (sot/state_of_aca/guide_acq_stats)
+
+    :param date: Date(s) (scalar or np.ndarray)
+    :param t_ccd: CD temperature(s) (degC, scalar or np.ndarray)
+    :param mag: Star magnitude(s) (scalar or np.ndarray)
+
+    :returns: Acquisition success probability(s)
+    """
+    raise NotImplementedError()
+
+
+def get_guide_success(date, t_ccd, mag):
+    """
+    Return probability of guide (bad_trak) success for given date, temperature and mag.
+
+    Any of the inputs can be scalars or arrays, with the output being the result of
+    the broadcasted dimension of the inputs.
+
+    This is based on the dark model and guide success fitting presented
+    in the State of the ACA 2013 (sot/state_of_aca/guide_acq_stats)
+
+    :param date: Date(s) (scalar or np.ndarray)
+    :param t_ccd: CD temperature(s) (degC, scalar or np.ndarray)
+    :param mag: Star magnitude(s) (scalar or np.ndarray)
+
+    :returns: Guide success probability(s)
+    """
+    raise NotImplementedError()


### PR DESCRIPTION
Functionality to include:
- Get dark cal image(s) associated with previous calibrations
- Get properties of calibrations, including all tabulated data in dark cal reports
- Get CCD dark current model for given time and temperature
- Get guide and acq success predictions for mag, time, temperature.  This is slightly off-topic but is related to overall trending.  If it seems sensible this could be moved somewhere else.

The first two could live in `dark_cal.py` and the second two in `dark_model.py`.  I plan to make an initial stub of this structure and attach code.
