### PR TITLE
Change setup.py to use distutils not setuptools; add aca_dark package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,19 @@
-from setuptools import setup, find_packages
+from distutils.core import setup
+
 from mica.version import version
+
+license = """\
+New BSD/3-clause BSD License
+Copyright (c) 2012 Smithsonian Astrophysical Observatory
+All rights reserved."""
+
 setup(name='mica',
+      description='Mica aspects archive',
       version=str(version),
       author='Jean Connelly',
       author_email='jconnelly@cfa.harvard.edu',
-      license="""New BSD/3-clause BSD License
-Copyright (c) 2012 Smithsonian Astrophysical Observatory
-All rights reserved.""",
+      license=license,
       zip_safe=False,
-      packages=['mica', 'mica.archive', 'mica.vv',
-                'mica.starcheck', 'mica.catalog',
-                'mica.report'],
+      packages=['mica', 'mica.archive', 'mica.aca_dark', 'mica.vv',
+                'mica.starcheck', 'mica.catalog', 'mica.report'],
       )


### PR DESCRIPTION
@jeanconn - making this a quick PR so you get visibility.  I got fed up with the fact that the way eggs and setuptools work makes it very difficult to develop script code locally without installing every time.  Maybe you found an answer, but basically all the eggs (in flight Ska) were taking precedence over the local packages.  Even PYTHONPATH didn't help:

 http://stackoverflow.com/questions/5984523/eggs-in-path-before-pythonpath-environment-variable

Anyway, distutils is just fine (preferred) for non-namespace packages.  There is a possibility that these problems are fixed in the latest setuptools 2.0 but I haven't gone there.
