### PR TITLE
Use different way to filter bad hdr3 records due to 4x4, 6x6 transition

### DIFF
--- a/mica/archive/aca_hdr3.py
+++ b/mica/archive/aca_hdr3.py
@@ -501,11 +501,12 @@ class MSIDset(collections.OrderedDict):
             # break in L0 decom, typically due to a change to 4x4 or 6x6 data.
             #  t[0] = 1.0
             #  t[1] = 5.1   <= This record could be bad, as indicated by the gap afterward
-            #  t[2] = 17.8
-            #  t[3] = 21.9
+            #  t[2, 3] = 17.4, 21.5
+            # To form the time diffs first add `tstop` to the end so that if 8x8 data
+            # does not extend through `tstop` then the last record gets chopped.
             dt = np.diff(np.concatenate([slot_data['TIME'], [tstop]]))
             bad = np.abs(dt - 4.1) > 1e-3
-            slot_data[np.where(bad)] = ma.masked
+            slot_data[bad] = ma.masked
 
             # Chop off the padding
             i_stop = np.searchsorted(slot_data['TIME'], self.tstop, side='right')


### PR DESCRIPTION
There is a problem in the logic that filters out bad 8x8 records at the end of each file.  I wasn't able to understand exactly why the original code was failing, but this PR proposes a different way of doing the filtering that seems to work.

```
>>> d = aca_hdr3.Msid('ccd_temp', 474314333, 474314400)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-7-8073be901f27> in <module>()
----> 1 d = aca_hdr3.Msid('ccd_temp', 474314333, 474314400)

/data/baffin/tom/git/mica/mica/archive/aca_hdr3.pyc in __init__(self, msid, start, stop)
    435 
    436     def __init__(self, msid, start, stop):
--> 437         super(Msid, self).__init__(msid, start, stop, filter_bad=True)
    438 
    439 

/data/baffin/tom/git/mica/mica/archive/aca_hdr3.pyc in __init__(self, msid, start, stop, msid_data, filter_bad)
    367     def __init__(self, msid, start, stop, msid_data=None, filter_bad=False):
    368         if msid_data is None:
--> 369             msid_data = MSIDset([msid], start, stop)[msid]
    370         self.msid = msid
    371         self.tstart = DateTime(start).secs

/data/baffin/tom/git/mica/mica/archive/aca_hdr3.pyc in __init__(self, msids, start, stop)
    508             for file in slot_files[last_eight]['filename']:
    509                 # last index from that file in the data
--> 510                 max_idx = np.max(np.flatnonzero(slot_data['FILENAME'] == file))
    511                 if max_idx:
    512                     slot_data[max_idx] = ma.masked

/proj/sot/ska/arch/x86_64-linux_CentOS-5/lib/python2.7/site-packages/numpy/core/fromnumeric.pyc in amax(a, axis, out)
   1831     except AttributeError:
   1832         return _wrapit(a, 'max', axis, out)
-> 1833     return amax(axis, out)
   1834 
   1835 

ValueError: zero-size array to maximum.reduce without identity
```
