### PR TITLE
Only rerun on new data

### DIFF
--- a/mica/archive/obsid_archive.py
+++ b/mica/archive/obsid_archive.py
@@ -328,7 +328,7 @@ class ObsArchive:
                 "select distinct obi from obidet_0_5 where obsid = %d" % obsid)
         if len(obis) > 1:
             minobi = np.min(obis['obi'])
-            logger.info("limiting arc5gl to obi %d" % minobi)
+            logger.debug("limiting arc5gl to obi %d" % minobi)
             arc5.sendline("obi=%d" % minobi)
         if version != 'default':
             arc5.sendline("version=%s" % version)


### PR DESCRIPTION
This code was attempting to get new asp1 products and rerun V&V
for all obsids that had "pending" or provisional data.  These changes
set it to fetch and check the version numbers of the content it has
and the "default" content and try to only fetch and redo V&V
(or mark to have V&V redone) if the state in the database has really
changed.