### PR TITLE
Fix include_image option in aca_dark.get_dark_cal_props_table

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -217,7 +217,7 @@ def get_dark_cal_props_table(start=None, stop=None, include_image=False, as_tabl
                  if dark_id >= start_id and dark_id <= stop_id]
 
     # Get the list of properties structures
-    props = [get_dark_cal_props(dark_id) for dark_id in dark_dirs]
+    props = [get_dark_cal_props(dark_id, include_image=include_image) for dark_id in dark_dirs]
 
     if as_table:
         for prop in props:


### PR DESCRIPTION
```
Help on function get_dark_cal_props_table in module mica.archive.aca_dark.dark_cal:

get_dark_cal_props_table(start=None, stop=None, include_image=False, as_table=True)
    Return a table of dark calibration properties between ``start`` and ``stop``.
    
    If ``include_image`` is True then an additional column or key ``image`` is
    defined which contains the corresponding 1024x1024 dark cal image.
```

```
----> 1 aca_dark.get_dark_cal_props_table(include_image=True)

/proj/sot/ska/arch/x86_64-linux_CentOS-5/lib/python2.7/site-packages/mica/archive/aca_dark/dark_cal.pyc in get_dark_cal_props_table(start, stop, include_image, as_table)
    225         table_props = Table(props)
    226         if include_image:
--> 227             x = np.vstack([prop['image'][np.newaxis, :] for prop in props])
    228             images = Column(x)
    229             table_props['image'] = images

KeyError: 'image'
```