### PR TITLE
Add function to get obspar obsids within a date range

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -323,6 +323,12 @@ Methods are also provided to retrieve a list of files by obsid and time range.
    ...                          stop='2012:030')
 
 
+And a method is provided to fetch obsids that have obspars:
+
+   >>> obspar.get_obsids('2016:001', '2016:002')
+   [51365, 18736, 18036, 18203]
+
+
 .. _stats-label:
 
 Mica.stats

--- a/mica/archive/obspar.py
+++ b/mica/archive/obspar.py
@@ -344,11 +344,14 @@ def get_obsids(start=None, stop=None, revision=None):
       >>> from mica.archive import obspar
       >>> obsids = obspar.get_obsids('2015:001', '2015:003')
 
+    To retrieve the complete set of obsids used over a time range,
+    use kadi (kadi.events.obsid) instead of this obspar-based method.
 
     :param start: time range start (Chandra.Time compatible)
     :param stop: time range stop (Chandra.Time compatible)
-    :param revision: revision integer or 'last'
-                     defaults to current released version
+    :param revision: None, revision integer, or 'last'
+                     None is equivalent to limiting the search
+                     to those with 'default'/released obspars.
     :returns: list of obsids
     """
     files = archive._get_file_records(start=start, stop=stop,

--- a/mica/archive/obspar.py
+++ b/mica/archive/obspar.py
@@ -337,6 +337,27 @@ def get_files(obsid=None, start=None, stop=None, revision=None):
                              revision=revision)
 
 
+def get_obsids(start=None, stop=None, revision=None):
+    """
+    List obsids with obspars in a time range.
+
+      >>> from mica.archive import obspar
+      >>> obsids = obspar.get_obsids('2015:001', '2015:003')
+
+
+    :param start: time range start (Chandra.Time compatible)
+    :param stop: time range stop (Chandra.Time compatible)
+    :param revision: revision integer or 'last'
+                     defaults to current released version
+    :returns: list of obsids
+    """
+    files = archive._get_file_records(start=start, stop=stop,
+                                      revision=revision)
+    if len(files) == 0:
+        return []
+    return files['obsid'].tolist()
+
+
 def main():
     """
     Run the update process to get new obspars, save them in the Ska

--- a/mica/archive/tests/test_obspar.py
+++ b/mica/archive/tests/test_obspar.py
@@ -1,0 +1,17 @@
+from .. import obspar
+
+def test_get_obsids():
+    """
+    Test that archive.obspar.get_obsids gets a reasonable set of obsids.
+    """
+    start = "2016:001"
+    stop = "2016:005"
+    mica_obs = obspar.get_obsids(start, stop)
+    # from kadi.events.obsids.filter(start, stop)
+    kadi_obsid_list = [51365, 18736, 18036, 18203, 18119,
+                       18737, 51364, 51363, 51362, 51361,
+                       18216, 16821, 17023, 18293, 18623,
+                       18248]
+    assert len(kadi_obsid_list) == len(mica_obs)
+    for o1, o2 in zip(kadi_obsid_list, mica_obs):
+        assert o1 == o2


### PR DESCRIPTION
There doesn't seem to be a convenient way to get all the obsids that have an available obspar file in the archive within a `start` / `stop` date range.