### PR TITLE
Add parameter to specify scaling factor in dark_temp_scale

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -44,25 +44,31 @@ def dark_id_to_date(dark_id):
     return '{}:{}'.format(dark_id[:4], dark_id[4:])
 
 
-def dark_temp_scale(t_ccd, t_ccd_ref=-19.0):
+def dark_temp_scale(t_ccd, t_ccd_ref=-19.0, scale_4c=1.0 / 0.70):
     """
     Return the multiplicative scale factor to convert a CCD dark map from
-    the actual temperature ``t_ccd`` to the reference temperature ``t_ccd_ref``.
+    the actual temperature ``t_ccd`` to the reference temperature ``t_ccd_ref``::
+
+      scale_4c ** ((t_ccd_ref - t_ccd) / 4.0)
 
     Based on best global fit for dark current model in `plot_predicted_warmpix.py`.
-    Previous value was 0.62 instead of 0.70.  This represents the change in
-    dark current for each 4 degC decrease::
+    This represents the multiplicative change in dark current for each 4 degC
+    increase::
 
-      >>> from mica.archive.aca_dark import temp_scalefac
-      >>> print temp_scalefac(t_ccd=-15, t_ccd_ref=-19)
+      >>> from mica.archive.aca_dark import dark_temp_scale
+      >>> print(dark_temp_scale(t_ccd=-15, t_ccd_ref=-19))
       0.7
+
+    The default value for ``scale_4c`` is written as 1.0 / 0.7 because the
+    equation was previously written using 1 / scale_4c with a value of 0.7.
 
     :param t_ccd: actual temperature (degC)
     :param t_ccd_ref: reference temperature (degC, default=-19.0)
+    :param scale_4c: increase in dark current per 4 degC increase
 
     :returns: scale factor
     """
-    return np.exp(np.log(0.70) / 4.0 * (t_ccd - t_ccd_ref))
+    return scale_4c ** ((t_ccd_ref - t_ccd) / 4.0)
 
 
 @lru_cache()

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -14,6 +14,7 @@ from mica.common import MICA_ARCHIVE_PATH, MissingDataError
 from . import file_defs
 
 DARK_CAL = pyyaks.context.ContextDict('dark_cal')
+DARK_SCALE_4C = 1.0 / 0.70  # Increase in dark current per 4 degC increase in T_ccd
 
 SKA_FILES = pyyaks.context.ContextDict('ska_files', basedir='/proj/sot/ska')
 SKA_FILES.update(file_defs.SKA_FILES)
@@ -44,7 +45,7 @@ def dark_id_to_date(dark_id):
     return '{}:{}'.format(dark_id[:4], dark_id[4:])
 
 
-def dark_temp_scale(t_ccd, t_ccd_ref=-19.0, scale_4c=1.0 / 0.70):
+def dark_temp_scale(t_ccd, t_ccd_ref=-19.0, scale_4c=None):
     """
     Return the multiplicative scale factor to convert a CCD dark map from
     the actual temperature ``t_ccd`` to the reference temperature ``t_ccd_ref``::
@@ -68,6 +69,9 @@ def dark_temp_scale(t_ccd, t_ccd_ref=-19.0, scale_4c=1.0 / 0.70):
 
     :returns: scale factor
     """
+    if scale_4c is None:
+        scale_4c = DARK_SCALE_4C
+
     return scale_4c ** ((t_ccd_ref - t_ccd) / 4.0)
 
 

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -46,26 +46,32 @@ def dark_id_to_date(dark_id):
 
 
 def dark_temp_scale(t_ccd, t_ccd_ref=-19.0, scale_4c=None):
-    """
-    Return the multiplicative scale factor to convert a CCD dark map from
-    the actual temperature ``t_ccd`` to the reference temperature ``t_ccd_ref``::
+    """Return the multiplicative scale factor to convert a CCD dark map
+    or dark current value from temperature ``t_ccd`` to temperature
+    ``t_ccd_ref``::
 
-      scale_4c ** ((t_ccd_ref - t_ccd) / 4.0)
+      scale = scale_4c ** ((t_ccd_ref - t_ccd) / 4.0)
 
-    Based on best global fit for dark current model in `plot_predicted_warmpix.py`.
-    This represents the multiplicative change in dark current for each 4 degC
-    increase::
+    In other words, if you have a dark current value that corresponds to ``t_ccd``
+    and need the value at a different temperature ``t_ccd_ref`` then use the
+    the following.  Do not be misled by the misleading parameter names.
 
       >>> from mica.archive.aca_dark import dark_temp_scale
-      >>> print(dark_temp_scale(t_ccd=-15, t_ccd_ref=-19))
-      0.7
+      >>> scale = dark_temp_scale(t_ccd, t_ccd_ref, scale_4c)
+      >>> dark_curr_at_t_ccd_ref = scale * dark_curr_at_t_ccd
 
-    The default value for ``scale_4c`` is written as 1.0 / 0.7 because the
-    equation was previously written using 1 / scale_4c with a value of 0.7.
+    The default value for ``scale_4c`` is 1.0 / 0.7.  It is written this way
+    because the equation was previously expressed using 1 / scale_4c with a
+    value of 0.7. This value is based on best global fit for dark current model
+    in `plot_predicted_warmpix.py`.  This represents the multiplicative change
+    in dark current for each 4 degC increase::
+
+      >>> dark_temp_scale(t_ccd=-18, t_ccd_ref=-10, scale_4c=2.0)
+      4.0
 
     :param t_ccd: actual temperature (degC)
     :param t_ccd_ref: reference temperature (degC, default=-19.0)
-    :param scale_4c: increase in dark current per 4 degC increase
+    :param scale_4c: increase in dark current per 4 degC increase (default=1.0 / 0.7)
 
     :returns: scale factor
     """

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -19,6 +19,9 @@ def test_dark_temp_scale():
     scale = dark_cal.dark_temp_scale(-10., -14)
     assert np.allclose(scale, 0.70)
 
+    scale = dark_cal.dark_temp_scale(-10., -14, scale_4c=2.0)
+    assert scale == 0.5  # Should be an exact match
+
 
 def test_get_dark_cal_id():
     assert dark_cal.get_dark_cal_id('2007:008', 'nearest') == '2007006'


### PR DESCRIPTION
This changes the parametrization so that `scale_4c` is the multiplicative *increase* for each 4 degC *increase*.  Thus a bigger value is more increase.  That makes more sense and matches the way it was done for annealing.

This routine is back-compatible however.