### PR TITLE
Improve multiple aspect interval warnings

### DIFF
--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -532,7 +532,7 @@ class Obi(object):
         for gs in getattr(ai, 'gsprop'):
             self.slot_report[str(gs.slot)] = dict(
                 slot=gs.slot,
-                type='GUIDE')
+                type=gs['type'].rstrip())
         if getattr(ai, 'fidprop') is not None:
             self.fid_list = list(getattr(ai, 'fidprop').slot)
             for fl in getattr(ai, 'fidprop'):

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -127,14 +127,14 @@ class Obi(object):
         self._find_aspect_intervals()
         self._process_aspect_intervals()
         self._concat_slot_data()
-        try:
-            self._check_over_intervals()
-        except InconsistentAspectIntervals as e:
-            self._errors.append(e)
         self._sim_data()
         self.slot_report = dict()
         self._label_slots()
         self._agg_slot_data()
+        try:
+            self._check_over_intervals()
+        except InconsistentAspectIntervals as e:
+            self._errors.append(e)
         self._get_info()
 
     def save_plots_and_resid(self):


### PR DESCRIPTION
For warnings like:

"Warning: obsid 18842 has 2 aspect intervals"

it would be good to included "(has monitor window)" if, in fact, the observation does.  If it doesn't an email warn on this error would be useful.