### PR TITLE
Nav links in report sub-pages

### DIFF
--- a/templates/vv_slots_single.html
+++ b/templates/vv_slots_single.html
@@ -27,6 +27,8 @@
 </HEAD>
 <BODY>
 
+<P><A HREF="index.html">Full Report</A> <A HREF="vv.html">VV Report</A></P>
+
 <div id="left" class="border">
 <table>
 {% for field in ['slot', 'type', 'id_status'] %}<TR><TH align="left">{{ field }}</TH><TD align="left">{{ vv['slots'][slot][field] }}</TD></TR>


### PR DESCRIPTION
When I am given a direct link like https://icxc.cfa.harvard.edu/aspect/mica_reports/16/16359/slot_4.html there is no easy way to get back to the main V&V report page.
