### PR TITLE
Changes to get obsid 18625 to display in kadi acq table app

### DIFF
--- a/mica/version.py
+++ b/mica/version.py
@@ -14,7 +14,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '0.5.4dev'
+version = '0.5.4'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])

--- a/mica/web/pcad_table.py
+++ b/mica/web/pcad_table.py
@@ -85,7 +85,9 @@ def get_acq_table(obsid):
     # Get the catalog for the stars
     # This is used both to map ACQID to the right slot and
     # to get the star positions to estimate deltas later
-    starcheck = mica.starcheck.get_starcheck_catalog(int(obsid))
+    timeline_at_acq = mica.starcheck.starcheck.get_timeline_at_date(manvr.start)
+    starcheck = mica.starcheck.get_starcheck_catalog(int(obsid),
+                                                     mp_dir=timeline_at_acq['mp_dir'])
     if 'cat' not in starcheck:
         raise ValueError('No starcheck catalog found for {}'.format(obsid))
     catalog = Table(starcheck['cat'])

--- a/mica/web/pcad_table.py
+++ b/mica/web/pcad_table.py
@@ -86,8 +86,11 @@ def get_acq_table(obsid):
     # This is used both to map ACQID to the right slot and
     # to get the star positions to estimate deltas later
     timeline_at_acq = mica.starcheck.starcheck.get_timeline_at_date(manvr.start)
+    mp_dir = None
+    if timeline_at_acq is not None:
+        mp_dir = timeline_at_acq['mp_dir']
     starcheck = mica.starcheck.get_starcheck_catalog(int(obsid),
-                                                     mp_dir=timeline_at_acq['mp_dir'])
+                                                     mp_dir=mp_dir)
     if 'cat' not in starcheck:
         raise ValueError('No starcheck catalog found for {}'.format(obsid))
     catalog = Table(starcheck['cat'])

--- a/mica/web/pcad_table.py
+++ b/mica/web/pcad_table.py
@@ -51,8 +51,7 @@ def deltas_vs_obc_quat(vals, times, catalog):
         if star['PM_DEC'] != -9999:
             dec = star['DEC'] + star['PM_DEC'] * pm_to_degrees
         star_pos_eci = Ska.quatutil.radec2eci(ra, dec)
-        d_aca = np.dot(np.dot(aca_misalign, Ts.transpose(0, 2, 1)),
-                       star_pos_eci).transpose()
+        d_aca = np.dot(np.dot(aca_misalign, Ts.transpose(0, 2, 1)), star_pos_eci).transpose()
         yag = np.arctan2(d_aca[:, 1], d_aca[:, 0]) * R2A
         zag = np.arctan2(d_aca[:, 2], d_aca[:, 0]) * R2A
         dy[slot] = vals['AOACYAN{}'.format(slot)] - yag
@@ -71,8 +70,7 @@ def get_acq_table(obsid):
     stop_time = start_time + (60 * 5)
     acq_data = fetch.MSIDset(msids + slot_msids, start_time, stop_time)
 
-    vals = Table([acq_data[col].vals for col in msids],
-                 names=msids)
+    vals = Table([acq_data[col].vals for col in msids], names=msids)
     for field in slot_msids:
         vals.add_column(Column(name=field, data=acq_data[field].vals))
         times = Table([acq_data['AOACASEQ'].times], names=['time'])
@@ -87,8 +85,7 @@ def get_acq_table(obsid):
     # to get the star positions to estimate deltas later
     timeline_at_acq = mica.starcheck.starcheck.get_timeline_at_date(manvr.start)
     mp_dir = None if (timeline_at_acq is None) else timeline_at_acq['mp_dir']
-    starcheck = mica.starcheck.get_starcheck_catalog(int(obsid),
-                                                     mp_dir=mp_dir)
+    starcheck = mica.starcheck.get_starcheck_catalog(int(obsid), mp_dir=mp_dir)
     if 'cat' not in starcheck:
         raise ValueError('No starcheck catalog found for {}'.format(obsid))
     catalog = Table(starcheck['cat'])
@@ -98,20 +95,16 @@ def get_acq_table(obsid):
     slot_for_pos = [cat_row['slot'] for cat_row in catalog]
     pos_for_slot = dict([(slot, idx) for idx, slot in enumerate(slot_for_pos)])
     # Also, save out the starcheck index for each slot for later
-    index_for_slot = dict([(cat_row['slot'], cat_row['idx'])
-                           for cat_row in catalog])
+    index_for_slot = dict([(cat_row['slot'], cat_row['idx']) for cat_row in catalog])
 
     # Estimate the offsets from the expected catalog positions
     dy, dz = deltas_vs_obc_quat(vals, times['time'], catalog)
     for slot in range(0, 8):
-        vals.add_column(Column(name='dy{}'.format(slot),
-                               data=dy[slot].data))
-        vals.add_column(Column(name='dz{}'.format(slot),
-                               data=dz[slot].data))
+        vals.add_column(Column(name='dy{}'.format(slot), data=dy[slot].data))
+        vals.add_column(Column(name='dz{}'.format(slot), data=dz[slot].data))
         cat_entry = catalog[catalog['slot'] == slot][0]
         dmag = vals['AOACMAG{}'.format(slot)] - cat_entry['mag']
-        vals.add_column(Column(name='dmag{}'.format(slot),
-                               data=dmag.data))
+        vals.add_column(Column(name='dmag{}'.format(slot), data=dmag.data))
 
     # make a list of dicts of the table
     simple_data = []

--- a/mica/web/pcad_table.py
+++ b/mica/web/pcad_table.py
@@ -86,9 +86,7 @@ def get_acq_table(obsid):
     # This is used both to map ACQID to the right slot and
     # to get the star positions to estimate deltas later
     timeline_at_acq = mica.starcheck.starcheck.get_timeline_at_date(manvr.start)
-    mp_dir = None
-    if timeline_at_acq is not None:
-        mp_dir = timeline_at_acq['mp_dir']
+    mp_dir = None if (timeline_at_acq is None) else timeline_at_acq['mp_dir']
     starcheck = mica.starcheck.get_starcheck_catalog(int(obsid),
                                                      mp_dir=mp_dir)
     if 'cat' not in starcheck:


### PR DESCRIPTION
Changes to get obsid 18625 to display in kadi acq table app

This also has the side-effect that the display will include the times through the start of KALM if present, and 5 minutes of data if there is no transition to KALM in the interval.