### PR TITLE
Update CDA script and improve debugging output

### DIFF
--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -145,15 +145,17 @@ def update_cda_table(data_root=None,
                 row['filetime'] = file['filetime']
                 row.append()
             tbl.flush()
+    # Just fetching errors instead of quitting with bad status
+    except urllib.error.URLError as err:
+        logger.info(err)
+    # Otherwise print the new lines if available to log and reraise
     except Exception as err:
         if new_lines is not None:
             logger.info("Text of attempted table")
             logger.info("".join(new_lines))
-            raise(err)
+        raise(err)
     finally:
         h5f.close()
-
-
 
 def main():
     opt = get_options()

--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -1,4 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+"""
+Maintain a table with a list of of aca level 0 files in the Chandra Data Archive.
+
+This module calls the CGI available from:
+
+https://icxc.harvard.edu/dbtm/CDA/aspect_fetch.html
+
+fetches the list of aca0 files, and updates a full list of files in 'MICA_ARCHIVE/aca0/cda_aca0.h5'.
+That list should be of all available aca level 0 files in the Chandra Data Archive.  When called
+from the update_aca_l0.py update script in the mica cron job, this module attempts to use the end
+of the complete data in cda_aca0.h5 to form the query for new files, so only recent file names
+are fetched.
+
+The list of files in cda_aca0.h5 is compared against the list of files that have been archived in
+MICA_ARCHIVE so that none are missed.
+"""
+
 import os
 import re
 import tables

--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -53,7 +53,7 @@ def get_options():
 
 
 def make_data_table(lines):
-    files = Table.read(lines, format='ascii.csv',
+    files = Table.read(lines, format='ascii.csv', guess=False,
                        names=['filename', 'status', 'ingest_time'])
     # replace variable spaces with single spaces and then strptime
     ingest_dates = [time.strftime(

--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -2,13 +2,12 @@
 import os
 import re
 import tables
-import asciitable
+from astropy.table import Table, Column
 import numpy as np
 from six.moves import urllib, zip
 
 import time
 from Chandra.Time import DateTime
-import Ska.Numpy
 import logging
 import argparse
 
@@ -37,8 +36,8 @@ def get_options():
 
 
 def make_data_table(lines):
-    files = asciitable.read(lines,
-                            names=['filename', 'status', 'ingest_time'])
+    files = Table.read(lines, format='ascii.csv',
+                       names=['filename', 'status', 'ingest_time'])
     # replace variable spaces with single spaces and then strptime
     ingest_dates = [time.strftime(
             "%Y:%j:%H:%M:%S.000",
@@ -51,11 +50,11 @@ def make_data_table(lines):
     filetimes = [int(file_re.search(f).group(1)) for f in files['filename']]
     versions = [int(file_re.search(f).group(2)) for f in files['filename']]
     now_dates = np.repeat(DateTime().date, len(ingest_dates))
-    files = Ska.Numpy.add_column(files, 'ingest_date', ingest_dates)
-    files = Ska.Numpy.add_column(files, 'aca_ingest', now_dates)
-    files = Ska.Numpy.add_column(files, 'filetime', filetimes)
-    files = Ska.Numpy.add_column(files, 'version', versions)
-    files.sort(order=['aca_ingest', 'ingest_date', 'filename'])
+    files.add_column(Column(ingest_dates, 'ingest_date'))
+    files.add_column(Column(now_dates, 'aca_ingest'))
+    files.add_column(Column(filetimes, 'filetime'))
+    files.add_column(Column(versions, 'version'))
+    files.sort(['aca_ingest', 'ingest_date', 'filename'])
     return files
 
 

--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -19,7 +19,7 @@ MICA_ARCHIVE so that none are missed.
 import os
 import re
 import tables
-from astropy.table import Table, Column
+from astropy.table import Table
 import numpy as np
 from six.moves import urllib, zip
 

--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -63,14 +63,11 @@ def make_data_table(lines):
                     for t in
                     [' '.join(f.split())
                      for f in files['ingest_time']]]
+    files['ingest_date'] = ingest_dates
     file_re = re.compile(r'acaf(\d{9,})N(\d{3})_(\d)_img0.fits(\.gz)?')
-    filetimes = [int(file_re.search(f).group(1)) for f in files['filename']]
-    versions = [int(file_re.search(f).group(2)) for f in files['filename']]
-    now_dates = np.repeat(DateTime().date, len(ingest_dates))
-    files.add_column(Column(ingest_dates, 'ingest_date'))
-    files.add_column(Column(now_dates, 'aca_ingest'))
-    files.add_column(Column(filetimes, 'filetime'))
-    files.add_column(Column(versions, 'version'))
+    files['aca_ingest'] = np.repeat(DateTime().date, len(ingest_dates))
+    files['filetime'] = [int(file_re.search(f).group(1)) for f in files['filename']]
+    files['version'] = [int(file_re.search(f).group(2)) for f in files['filename']]
     files.sort(['aca_ingest', 'ingest_date', 'filename'])
     return files
 

--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -106,7 +106,9 @@ def update_cda_table(data_root=None,
     table_file = os.path.join(data_root, cda_table)
     if not os.path.exists(table_file):
         make_table_from_scratch(table_file, cda_fetch_url)
+        return
 
+    # Do an update
     h5f = tables.openFile(table_file, 'a')
     try:
         tbl = h5f.getNode('/', 'data')

--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -86,7 +86,7 @@ def make_table_from_scratch(table_file, cda_fetch_url, start='2015:001'):
                           filters=tables.Filters(complevel=5, complib='zlib'))
     desc, bo = tables.table.descr_from_dtype(files[0].dtype)
     tbl = h5f.createTable('/', 'data', desc)
-    tbl.append(files)
+    tbl.append(files.as_array())
     tbl.flush()
     h5f.close()
 


### PR DESCRIPTION
Update CDA script and improve debugging output.

Current failures in the cron job aren't reproducible at the cmd line and there isn't enough output from the cron job failures to see what is going on.  This PR should at least close the hdf5 file properly and might give enough debugging output to see  if there is a problem with the source data from the url.
