### PR TITLE
Add get_l0_images function for ACA L0 using ACAImage class

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -52,6 +52,7 @@ Functions
 
 .. autofunction:: get_slot_data
 .. autofunction:: get_files
+.. autofunction:: get_l0_images
 
 
 :mod:`mica.archive.asp_l1`

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -256,6 +256,45 @@ to create this:
 
    .. image:: plots/slot_2.gif
 
+An alternate way to access ACA L0 image is via the
+:func:`~mica.archive.aca_l0.get_l0_images()` function.  This returns a Python list of
+`ACAImage` objects (see the ``chandra_aca.aca_image`` docs for details).  Each of these
+objects contains the image along with relevant meta-data for each readout:: ``['TIME',
+'IMGROW0', 'IMGCOL0', 'BGDAVG', 'IMGSTAT', 'IMGFUNC1', 'IMGSIZE', 'INTEG']``.
+
+For example::
+
+  >>> imgs = aca_l0.get_l0_images(98585849, 98585884, slot=2)
+  >>> imgs[0]  # ACAImage rounds the values for viewing
+  <ACAImage row0=-246 col0=116
+  array([[  32,   81,   81,  212,  262,   98,   32,   27],
+         [  21,   48,  305, 1170,  830,  169,   65,   38],
+         [  38,   87,  825, 3434, 2635,  393,  147,   59],
+         [  54,  114,  508, 3614, 5408, 1284,  398,   92],
+         [  76,  163,  448, 2548, 5534, 1547,  344,  202],
+         [  65,  103,  256,  809, 2602, 1656,  426,  114],
+         [  16,   38,   54,  327, 1416, 1574,  502,  114],
+         [  10,   16,   43,  103,  371, 1191,  491,   92]])>
+
+  >>> imgs[0].aca[-240, 118]  # Access row=-240, col=118
+  53.90625
+
+  >>> imgs[0].meta
+  {'BGDAVG': 25,
+   'IMGCOL0': 116,
+   'IMGFUNC1': 1,
+   'IMGROW0': -246,
+   'IMGSIZE': 8,
+   'IMGSTAT': 0,
+   'INTEG': 1.696,
+   'TIME': 98585849.940383524}
+
+  >>> imgs[0].TIME
+  98585849.940383524
+
+  >>> imgs[0].row0, imgs[0].col0  # shortcut: row0 => IMGROW0
+  (-246, 116)
+
 
 Aspect L1 products
 ------------------

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -178,6 +178,9 @@ a file archive of ACA L0 telemetry.  This telemetry is stored in
 directories by year and day-of-year, and ingested filenames are stored
 in a lookup table.  
 
+Get_files()
+^^^^^^^^^^^^
+
 Methods are provided to retrieve files and read those data files into
 data structures.
 
@@ -203,7 +206,10 @@ The values from those files may be read and plotted directly:
    .. image:: plots/tempccd_from_files.png
 
 
-This particular loop/plot will break if the images aren't filtered on
+Get_slot_data()
+^^^^^^^^^^^^^^^
+
+The loop/plot above will break if the images aren't filtered on
 "imgsize=[6, 8]", as the 'TEMPCCD' columns is only available in 6x6
 and 8x8 data.  That's one reason to use the convenience function
 :func:`~mica.archive.aca_l0.get_slot_data()`, as it places the values in a
@@ -256,9 +262,13 @@ to create this:
 
    .. image:: plots/slot_2.gif
 
+
+Get_l0_images()
+^^^^^^^^^^^^^^^
+
 An alternate way to access ACA L0 image is via the
 :func:`~mica.archive.aca_l0.get_l0_images()` function.  This returns a Python list of
-`ACAImage` objects (see the ``chandra_aca.aca_image`` docs for details).  Each of these
+``ACAImage`` objects (see the ``chandra_aca.aca_image`` docs for details).  Each of these
 objects contains the image along with relevant meta-data for each readout:: ``['TIME',
 'IMGROW0', 'IMGCOL0', 'BGDAVG', 'IMGSTAT', 'IMGFUNC1', 'IMGSIZE', 'INTEG']``.
 

--- a/mica/__init__.py
+++ b/mica/__init__.py
@@ -1,8 +1,8 @@
 from .version import __version__
 
 def test(*args, **kwargs):
-    """
+    '''
     Run py.test unit tests.
-    """
+    '''
     import testr
     return testr.test(*args, **kwargs)

--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -12,6 +12,7 @@ import collections
 import tables
 from itertools import count
 
+import six
 from six.moves import zip
 import Ska.DBI
 import Ska.arc5gl
@@ -229,7 +230,7 @@ def get_l0_images(start, stop, slot, imgsize=None, columns=None):
         if sz < 8:
             imgraw = imgraw[:sz, :sz]
 
-        meta = {name: col[i] for name, col in cols.iteritems() if col[i] != -9999}
+        meta = {name: col[i] for name, col in six.iteritems(cols) if col[i] != -9999}
         imgs.append(ACAImage(imgraw, meta=meta))
 
     return imgs

--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -872,5 +872,4 @@ def main():
     updater.update()
 
 if __name__ == '__main__':
-    # main()
-    pass
+    main()

--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -182,6 +182,12 @@ def get_l0_images(start, stop, slot, imgsize=None, columns=None):
       >>> imgs = aca_l0.get_l0_images('2012:001', '2012:002', slot=7)
       >>> imgs = aca_l0.get_l0_images('2005:001', '2005:002', slot=6, imgsize=[8])
 
+    The default columns are:
+    ['TIME', 'IMGROW0', 'IMGCOL0', 'BGDAVG', 'IMGSTAT', 'IMGFUNC1', 'IMGSIZE', 'INTEG']
+
+    The image pixel values are given in units of DN.  One can convert to e-/sec
+    by multiplying by (5 / INTEG).
+
     :param start: start time of requested interval
     :param stop: stop time of requested interval
     :param slot: slot number integer (in the range 0 -> 7)
@@ -191,7 +197,7 @@ def get_l0_images(start, stop, slot, imgsize=None, columns=None):
     :returns: list of ACAImage objects
     """
     if columns is None:
-        columns = ['TIME', 'BGDAVG', 'IMGSTAT', 'IMGFUNC1', 'IMGSIZE']
+        columns = ['TIME', 'BGDAVG', 'IMGSTAT', 'IMGFUNC1', 'IMGSIZE', 'INTEG']
     if 'IMGROW0' not in columns:
         columns.append('IMGROW0')
     if 'IMGCOL0' not in columns:

--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -224,7 +224,7 @@ def get_l0_images(start, stop, slot, imgsize=None, columns=None):
     cols = {name: dat[name] for name in columns}
 
     for i, row in enumerate(dat):
-        imgraw = imgraws[i].reshape(8, 8, order='F')
+        imgraw = imgraws[i].reshape(8, 8)
         sz = imgsizes[i]
         if sz < 8:
             imgraw = imgraw[:sz, :sz]

--- a/mica/archive/tests/test_aca_l0.py
+++ b/mica/archive/tests/test_aca_l0.py
@@ -1,0 +1,53 @@
+from __future__ import division
+
+from astropy.table import Table
+import numpy as np
+from mica.archive import aca_l0, asp_l1
+from Ska.Numpy import interpolate
+
+
+def test_get_l0_images():
+    """
+    Do a validation test of get_l0_images:
+    - Get 20 mins of image data for slot 6 of obsid 8008 (very nice clean stars)
+    - Do first moment centroids in row and col
+    - Compare to aspect pipeline FM centroids for same slot data
+
+    This is a deep test that all the signs are right.  If not then everything
+    breaks badly because the star image doesn't move in sync with row0, col0.
+    """
+    start = '2007:002:06:00:00'
+    stop = '2007:002:06:20:00'
+
+    imgs = aca_l0.get_l0_images(start, stop, slot=6)
+
+    files = asp_l1.get_files(8008, content=['ACACENT'])
+    acen = Table.read(files[0])
+    # Pick FM centroids for slot 6
+    ok = (acen['alg'] == 1) & (acen['slot'] == 6)
+    acen = acen[ok]
+
+    # Row and col centroids
+    rcs = []
+    ccs = []
+    times = [img.TIME for img in imgs]
+
+    # Easy way to do FM centroids with mgrid
+    rw, cw = np.mgrid[0:6, 0:6]
+    # rw = [[0, 0, 0, 0, 0, 0],
+    #       [1, 1, 1, 1, 1, 1],
+    #       [2, 2, 2, 2, 2, 2],
+    #       [3, 3, 3, 3, 3, 3],
+    #       [4, 4, 4, 4, 4, 4],
+    #       [5, 5, 5, 5, 5, 5]]
+
+    for img in imgs:
+        norm = np.sum(img)
+        rcs.append(np.sum(img * rw) / norm + img.row0)
+        ccs.append(np.sum(img * cw) / norm + img.col0)
+
+    rcen = interpolate(acen['cent_i'], acen['time'], times)
+    ccen = interpolate(acen['cent_j'], acen['time'], times)
+
+    assert np.all(np.abs(rcen - rcs) < 0.05)
+    assert np.all(np.abs(ccen - ccs) < 0.05)

--- a/mica/archive/tests/validate_dark_coords.ipynb
+++ b/mica/archive/tests/validate_dark_coords.ipynb
@@ -1,0 +1,232 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Validate dark cal coordinates and compare to dynamic dark map\n",
+    "\n",
+    "Use dynamic dark current sampling (on-the-fly warm pixels) in order to explicitly compare known pixel coordinate values to those in a dark cal map which is read by `aca_dark` routines.  This validates that the row/col coordinates in a dark map, accessed using the new standard `dark_map.aca[row, col]` idiom, is correct.\n",
+    "\n",
+    "Side goals:\n",
+    "- Demonstrate a real-world use of the `ACAImage` class from `chandra_aca.aca_image`\n",
+    "- Investigate for one case the variability of warm/hot pixels"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "\n",
+    "from Chandra.Time import DateTime\n",
+    "from kadi import events\n",
+    "from mica.archive import aca_l0, aca_dark\n",
+    "from chandra_aca.aca_image import ACAImage\n",
+    "import matplotlib.pyplot as plt\n",
+    "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "obsid = 50804  # Our favorite obsid with a faint star in slot 7\n",
+    "slot = 7\n",
+    "dwells = events.dwells.filter(obsid=obsid)\n",
+    "tstart = dwells[0].tstart\n",
+    "dur = 1000\n",
+    "\n",
+    "# Get 1000 seconds of images\n",
+    "imgs = aca_l0.get_l0_images(tstart, tstart + dur, slot=7)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Make a stack of 100 images (30x30) to hold dynamic dark current samples.\n",
+    "# This is an alternate implementation from the keyed deque version.\n",
+    "max_n_samples = 100\n",
+    "sz = 32  # +/- 16 pixels is plenty big\n",
+    "row0 = imgs[0].row0 - sz/2\n",
+    "col0 = imgs[0].col0 - sz/2\n",
+    "\n",
+    "# Stack (list) of pixel samples (ACAImage objects)\n",
+    "samples = [ACAImage(shape=(sz, sz), row0=row0, col0=col0) for i in range(max_n_samples)]\n",
+    "\n",
+    "# Keep track of how many samples for each pixel\n",
+    "n_samples = ACAImage(shape=(sz, sz), row0=row0, col0=col0, dtype=int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Trick to get a list of (r, c) tuples corresponding to the edge of 8x8 image\n",
+    "x = np.ones((8, 8))\n",
+    "x[1:7, 1:7] = 0\n",
+    "rcs = zip(*np.where(x == 1))\n",
+    "\n",
+    "# Do the actual work of collecting samples.  If there are more than\n",
+    "# max_n_samples then roll over.\n",
+    "for img in imgs:\n",
+    "    for r, c in rcs:\n",
+    "        row, col = r + img.row0, c + img.col0\n",
+    "        ii = n_samples.aca[row, col] % max_n_samples\n",
+    "        samples[ii].aca[row, col] = img.aca[row, col]\n",
+    "        n_samples.aca[row, col] += 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Get the row and column indices with at least 5 samples\n",
+    "rs, cs = np.where(n_samples > 5)\n",
+    "rows = rs + n_samples.row0\n",
+    "cols = cs + n_samples.col0\n",
+    "\n",
+    "# Find the bounding box and make a new ACAImage to contain it\n",
+    "rmin = np.min(rows)\n",
+    "rmax = np.max(rows)\n",
+    "cmin = np.min(cols)\n",
+    "cmax = np.max(cols)\n",
+    "dynam_dark_map = ACAImage(shape=(rmax-rmin+1, cmax-cmin+1),\n",
+    "                          row0=rmin, col0=cmin)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Go through the list of pixels that are sampled at least 5 times\n",
+    "for row, col in zip(rows, cols):\n",
+    "    values = [sample.aca[row, col] for sample in samples[:n_samples.aca[row, col]]]\n",
+    "    dynam_dark_map.aca[row, col] = np.median(values) * 5 / 1.696  # e-/sec"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "# Now get the nearest dark current calibration and make into an ACAImage object\n",
+    "dark_cal = aca_dark.get_dark_cal_image(tstart, select='nearest')\n",
+    "dark_cal = ACAImage(dark_cal, row0=-512, col0=-512)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Select the same box as our dynamic dark map.  This is guaranteed to\n",
+    "# cover the same absolute CCD pixels and have the same size.\n",
+    "dark_cal_map = dark_cal[dynam_dark_map]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# Set both maps to -50 where it is not sampled\n",
+    "\n",
+    "# First select only the dynam_dark_map section of the original n_samples array.\n",
+    "n_samples_map = n_samples[dynam_dark_map]\n",
+    "\n",
+    "rs, cs = np.where(n_samples_map <= 5)\n",
+    "rows = rs + n_samples_map.row0\n",
+    "cols = cs + n_samples_map.col0\n",
+    "for row, col in zip(rows, cols):\n",
+    "    dark_cal_map.aca[row, col] = -50\n",
+    "    dynam_dark_map.aca[row, col] = -50"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAiwAAAD7CAYAAABJ089XAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAALEgAACxIB0t1+/AAAFHJJREFUeJzt3X+s3XV9x/HXi95KwaoFQRApaedgKrgpc6ZTjN+ZzlRG\nkEQ2Zf5AsrktWxVMBNQ/9HTZEmw0YEaMoog4EeaKIZoJCOohAmqsIEJbBihNC6SlSkE0U1t47497\nWu6tt/ccvvf9vd/Pl/N8JCecc/j21Xd6zn3f1z333O91RAgAAKBkB7Q9AAAAwDAUFgAAUDwKCwAA\nKB6FBQAAFI/CAgAAikdhAQAAxZtoKtg2Py8NtCQi3PYMXcb+Ato10w5rrLBIkj4wwsf8LT3ptb3h\nx318rsPMRW9wmWdHjnjc4z3pOb2RDv3+ttzPYyuuGXGvX9mTzuiNduy6utPsx5dGPbCnkR7nJbUn\n2b9HRzmop9Geh3SVFNWIz+37e9Ly3uzH9BvoPxMjPs5P9KQFveHH7Z7LMPtx2IjH/bonPbs39LAN\nP89/bh9/8QiPzf/0pL/qjRZ441ym2Y+R9mxPo3+eerz2KPv33CH/v6fR55v5ceZbQgAAoHgUFgAA\nULz2C8vSqu0JRlC1PcDsnlW1PcFwJ1RtTzCCqu0BhqjaHgAzWVK1PcHsXLU9wXALq7YnmN2xVdsT\njKBqe4Ahqjkn1C4stlfZvtv2vbbPrz3BMVXtPzp/qrYHmN2BVdsTDPfyqu0JRlC1PcAQVdsDPGOk\n7S9JOqTKGaopB1QtDzCC0r/oOq5qe4IRVG0PMEQ154RahcX2AkkXS1ol6WWSzrD90jlPAwANY38B\n3VT3FZZXS7ovIjZHxC5JV0l6c95YANAY9hfQQXULy4skbZ1y+4HBfQBQOvYX0EF1CwsnVQLQVewv\noIPqnjjuQUlLp9xeqsmvUqa7pTfliKojb7AFuqY/uGBEo+2v+3tPXV9Slf/mWqCz+hplh9UtLOsl\nHWt7maSHJL1V0hm/d9QoZ7AFMEeVpr8Df007Y3THaPtr2NlrASSpNMoOq1VYImK37dWSrpe0QNKl\nEbGpThYAzCf2F9BNtX+XUERcK+naxFkAYF6wv4Duaf9MtwAAAENQWAAAQPEoLAAAoHgUFgAAUDwK\nCwAAKJ4jmjnpo+24Jt6YlnfaO69Py9prdXJelZzXS86TFGc5Nc9vbeD500/Oq/2zcPOUJ0m/yQyz\nIiL3gR4ztuMf4qK0vEsOPzsta69/Ss67IDlPkk7KjYsr8p/WfnPyDlufG9eMXQ1kLkzMmnmH8QoL\nAAAoHoUFAAAUj8ICAACKR2EBAADFo7AAAIDiUVgAAEDxKCwAAKB4FBYAAFA8CgsAACgehQUAABSP\nwgIAAIpHYQEAAMWjsAAAgOJRWAAAQPEoLAAAoHgUFgAAUDwKCwAAKB6FBQAAFI/CAgAAikdhAQAA\nxXNENBNsh5SYfVhe1F6/Ss47KTnvxuQ8SamPiSTJyXmSluTGfXPn61Lz3rjmu6l5kqReZpgVEQ08\nMONjcn89mRe4qIGH48jkvBXJeZK0LjlvdzOfr1ItyX+sv7zztNS8vz33mtQ8SdJFiVm7Z95hvMIC\nAACKR2EBAADFo7AAAIDiUVgAAEDxKCwAAKB4tQqL7aW2v2N7g+27bL8vezAAaAo7DOieiZp/bpek\n90fEj20vlvQj2zdExKbE2QCgKewwoGNqvcISEdsi4seD67+StEnSUZmDAUBT2GFA98z5PSy2l0l6\npaQfzDULAOYbOwzohrrfEpIkDV5KXSfp7MFXKfvoTbleDS4AcvUHFzxds++w3pTrldhfQEOe7EvR\nH3pY7cJie6GkqyV9KSL2c57fXt14ACOrNP2T6Zp2xuiY4TusN88TAWPqgErTdtjumXdY3Z8SsqRL\nJW2MiMzfIAAAjWOHAd1T9z0sr5X0Dkl/Yfv2wWVV4lwA0CR2GNAxtb4lFBE3i5POAegodhjQPXzA\nAgCA4lFYAABA8SgsAACgeBQWAABQPAoLAAAoniOimWA7tCox++N5UXu8/vjrUvP+y29KzTvy7xt4\nbL6QnLc7OU+STk/OOzo37rwL80/MtvZ/P5oX9hIrIpwXOH5sh6rEj7/s57Skxe/ekZq3/YgXpOZJ\n0rPfmbzDPt3E56tHcuOOfn5unpT+/OldeH5uoKTeho/lhZ0w8w7jFRYAAFA8CgsAACgehQUAABSP\nwgIAAIpHYQEAAMWjsAAAgOJRWAAAQPEoLAAAoHgUFgAAUDwKCwAAKB6FBQAAFI/CAgAAikdhAQAA\nxaOwAACA4lFYAABA8SgsAACgeBQWAABQPAoLAAAoHoUFAAAUzxHRTLAd0u/yAk9amJe1x13JeYuS\n87b1kgM7YkUvN+/7yc/xo52bJ+m8rWvSsta6p4jIH3KMTO6vJ/MCX9HAw7E5OW8iOU+Sft5rILRw\nK3v5mTcm77Al+c/Hi3b+Y1rWOb5kxh3GKywAAKB4FBYAAFA8CgsAACgehQUAABSPwgIAAIpHYQEA\nAMWbU2GxvcD27ba/njUQAMwH9hfQLXN9heVsSRslNXMyFwBoDvsL6JDahcX20ZJOlvQ5SZykCkBn\nsL+A7pnLKywXSjpXqaeDBIB5wf4COqbWyZhtnyLp4Yi43Xa1/yP/dcr11w8uADJt6d+vLf3NbY/R\nGaPvr96U69XgAiDbvf2HdF//oaHH1f3tEa+RdKrtkzX5G3Sea/uLEfGu6Yd9pGY8gFEdUy3XMdXy\nvbdvXXNTi9N0woj7qzf/kwFj6NjqKB1bHbX39vVrbpvxuFrfEoqID0fE0ohYLultkr79+x/sAFAe\n9hfQTVnnYeFd9gC6iv0FdMCcf6F4RNwkidegAXQO+wvoDs50CwAAikdhAQAAxaOwAACA4lFYAABA\n8SgsAACgeHP+KaFZHb0wL+v0vKi9bm4gE3NXJefdlfurYg7d/GBqniStXfjRxLReYtYYOyzxeXNK\nXtRe/5ac1+xng/GxqIHMidwddvjOLal5knTOIZ9JTLtkxnt5hQUAABSPwgIAAIpHYQEAAMWjsAAA\ngOJRWAAAQPEoLAAAoHgUFgAAUDwKCwAAKB6FBQAAFI/CAgAAikdhAQAAxaOwAACA4lFYAABA8Sgs\nAACgeBQWAABQPAoLAAAoHoUFAAAUj8ICAACKR2EBAADFc0Q0E2yHFudl/+jxl6Vl7fGn3picuCs5\n79+T87rhD+KvU/N+9qbjU/N0XW6cJOn0xKx1VkQ4MXHs2A4tyttfV//fyWlZe7zF30hObOJzwZoG\nMsv2J7EqPfOOM1bkBl6VGydJujgxa/XMO4xXWAAAQPEoLAAAoHgUFgAAUDwKCwAAKB6FBQAAFK92\nYbG9xPY625tsb7Sd/DZmAGgG+wvonok5/NlPSvpGRJxue0LSs5NmAoCmsb+AjqlVWGw/T9LrIuJM\nSYqI3ZIeyxwMAJrA/gK6qe63hJZL2mH7Mtu32f6s7YMzBwOAhrC/gA6q+y2hCUknSlodET+0fZGk\nD0r6yLSjftt76vqCSpqoav51APbr4b60o9/2FF0y2v7a1Xvq+gHV5A4DkO+evnRvf+hhdQvLA5Ie\niIgfDm6v0+QH/HQH9mrGAxjZC6rJyx6bxu906E/TaPtrYW8eRwLG2HHV5GWPa2feYbW+JRQR2yRt\ntX3c4K6VkjbUyQKA+cT+ArppLj8l9F5JV9h+lqSfSjorZyQAaBz7C+iY2oUlIu6Q9GeJswDAvGB/\nAd3DmW4BAEDxKCwAAKB4FBYAAFA8CgsAACgehQUAABSPwgIAAIo3l/OwDPeHeVHnam1e2B6Lk/N+\nszA17lO7NqfmSdI/H/SF3MBzcuMk6WfPSQ7cnZy3KDlPyn8uYu5W5kV9XB/IC2vKhNMjV+/K/RVN\nFy88LzVPkrQ+N+6O3E8Dk7J3WBNubv6v4BUWAABQPAoLAAAoHoUFAAAUj8ICAACKR2EBAADFo7AA\nAIDiUVgAAEDxKCwAAKB4FBYAAFA8CgsAACgehQUAABSPwgIAAIpHYQEAAMWjsAAAgOJRWAAAQPEo\nLAAAoHgUFgAAUDwKCwAAKB6FBQAAFM8R0UywHVqUmH1dXtReVQOZpZtIzvt0cp4krdyVm7d6YW7e\nzblxknT1zpPTst7iaxURTgscQ7ZDStxf1+RF7XVa9u5u4CmTvW+acEpy3knJeZJ0VXLe5uQ8Sb0d\n5+dlee2MO4xXWAAAQPEoLAAAoHgUFgAAUDwKCwAAKB6FBQAAFK92YbH9IdsbbN9p+8u2D8wcDACa\nwv4CuqdWYbG9TNJ7JJ0YES+XtEDS2/LGAoBmsL+Abqr7U/K/lLRL0sG2n5B0sKQH06YCgOawv4AO\nqvUKS0Q8IukTkrZIekjSoxFxY+ZgANAE9hfQTbVeYbH9YknnSFom6TFJ/2377RFxxbQDd/Weun5A\nJS2o6vx1AGZxV/8X2tB/pO0xOmPk/aXelOuVxvPU2EDz7u9v0eb+lqHH1f2W0Ksk3RoRv5Ak21+V\n9BpJ0z/gF/ZqxgMY1QnV83VC9fy9t7+y5r4Wp+mE0fbXtMICoCnLq2O0vDpm7+2b1tw643F1f0ro\nbkkrbB9k25JWStpYMwsA5hP7C+iguu9huUPSFyWtl/STwd2XZA0FAE1hfwHdVPt3aUbEWklrE2cB\ngHnB/gK6hzPdAgCA4lFYAABA8SgsAACgeBQWAABQPAoLAAAoniOimWA7tDgv+88f/3Za1h7fO+gN\nuYGLcuN0TXKeJK3OjTv8zuFnJ3y6dhxyzPCDnoaP7Xxvat75h/9Hap6k3MelZ0WEExPHju3QROJu\nXJ8XtdcrkvNq/8zoLNYl512QnCdp0XW5Z4n+zWGHpuZJ0nm71qTmrV340dQ8SdJ1iVkrZ95hvMIC\nAACKR2EBAADFo7AAAIDiUVgAAEDxKCwAAKB4FBYAAFA8CgsAACgehQUAABSPwgIAAIpHYQEAAMWj\nsAAAgOJRWAAAQPEoLAAAoHgUFgAAUDwKCwAAKB6FBQAAFI/CAgAAikdhAQAAxaOwAACA4lFYAABA\n8RwRzQTbocWJ2cvyovbalht3+I4tqXk7fExqniTpHblxD//nc3IDJb3gkMdzA0/IjdPNveTAbGsU\nEW57ii6zHVLi/npJXtRe9yXnvTs5T5K+kJz3quQ8SXF17oeKj2/gc+orkvP6veTAbDPvMF5hAQAA\nxaOwAACA4lFYAABA8SgsAACgeLMWFtuft73d9p1T7jvU9g2277H9TdtLmh8TAJ4+dhjwzDHsFZbL\nJK3a574PSrohIo6T9K3BbQAoETsMeIaYtbBExHcl7dzn7lMlXT64frmk0xqYCwDmjB0GPHPUeQ/L\nERGxfXB9u6QjEucBgKaxw4AOmtObbmPyrHPNnHkOABrGDgO6Y6LGn9lu+8iI2Gb7hZIe3u+Rv+09\ndX1BJU1UNf46ALPbPLhgRCPusN6U69XgAiDfZo2yw+oUlq9JOlPSxwb/vWa/Rx7YqxEP4OlZpum/\nu+KmdsbojhF3WG/eBgLG2zKNssOG/VjzlZJulfRHtrfaPkvSBZL+0vY9kt4wuA0AxWGHAc8cs77C\nEhFn7Od/rWxgFgBIxQ4Dnjk40y0AACgehQUAABSv/cKyu9/2BMP9rt/2BEP02x5gqFv6u9seYbhH\n+21PMMTmtgfAjPptDzC7J/ttTzBc4TP2b217ghHs7Lc9wRCb55zQfmF5ot/2BMPt6rc9wRD9tgcY\n6pb+E22PMNxj/bYnGGJz2wNgRv22B5hd9NueYLjCZ+x/r+0JRjAGX3C1X1gAAACGoLAAAIDiefLM\n1A0E25zuGmhJRLjtGbqM/QW0a6Yd1lhhAQAAyMK3hAAAQPEoLAAAoHitFhbbq2zfbfte2+e3Ocu+\nbC+1/R3bG2zfZft9bc+0P7YX2L7d9tfbnmVftpfYXmd7k+2Ntle0PdO+bH9o8DjfafvLtg8sYKbP\n295u+84p9x1q+wbb99j+pu0lbc447kreX1J3dljJ+0sqf4eN0/5qrbDYXiDpYkmrJL1M0hm2X9rW\nPDPYJen9EXG8pBWS/qWw+aY6W9JGSSW+IemTkr4RES+V9MeSNrU8zzS2l0l6j6QTI+LlkhZIelub\nMw1cpsmPjak+KOmGiDhO0rcGt9GCDuwvqTs7rOT9JRW8w8Ztf7X5CsurJd0XEZsjYpekqyS9ucV5\npomIbRHx48H1X2nySXpUu1P9PttHSzpZ0uckFfWTIbafJ+l1EfF5SYqI3RHxWMtj7euXmlzsB9ue\nkHSwpAfbHUmKiO9K2rnP3adKunxw/XJJp83rUJiq6P0ldWOHlby/pE7ssLHaX20WlhdJ2jrl9gOD\n+4ozaLGvlPSDdieZ0YWSzpX0ZNuDzGC5pB22L7N9m+3P2j647aGmiohHJH1C0hZJD0l6NCJubHeq\n/ToiIrYPrm+XdESbw4y5zuwvqegdVvL+kgrfYeO2v9osLKW+/DeN7cWS1kk6e/BVSjFsnyLp4Yi4\nXQV+dSJpQtKJkj4VESdK+rUK+zaG7RdLOkfSMk1+9bnY9ttbHWoEMXk+gk58DD1DdebfvtQd1oH9\nJRW+w8Ztf7VZWB6UtHTK7aWa/CqlGLYXSrpa0pci4pq255nBaySdavt+SVdKeoPtL7Y801QPSHog\nIn44uL1Okx/8JXmVpFsj4hcRsVvSVzX571qi7baPlCTbL5T0cMvzjLPi95dU/A4rfX9J5e+wsdpf\nbRaW9ZKOtb3M9rMkvVXS11qcZxrblnSppI0RcVHb88wkIj4cEUsjYrkm32j17Yh4V9tz7RER2yRt\ntX3c4K6Vkja0ONJM7pa0wvZBg8d8pSbfAFiir0k6c3D9TEmlfQIaJ0XvL6n8HVb6/pI6scPGan9N\npI7zNETEbturJV2vyXc2XxoRxbz7WtJrJb1D0k9s3z6470MRcV2LMw1T4svU75V0xWCp/1TSWS3P\nM01E3DH4qm69Jr+PfpukS9qdSrJ9paTXSzrM9lZJH5F0gaSv2P47Tf7q079pb8Lx1oH9JXVvh5W4\nv6SCd9i47S9OzQ8AAIrHmW4BAEDxKCwAAKB4FBYAAFA8CgsAACgehQUAABSPwgIAAIpHYQEAAMWj\nsAAAgOL9P79ll/nZXFckAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7f509ed01190>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "# Compare images <==>  LOOKS GOOD!\n",
+    "plt.close(0)\n",
+    "plt.figure(0, figsize=(10, 4))\n",
+    "vmin = -50\n",
+    "vmax = 450\n",
+    "plt.subplot(1, 2, 1)\n",
+    "plt.imshow(dark_cal_map, vmin=vmin, vmax=vmax, interpolation='nearest')\n",
+    "plt.subplot(1, 2, 2)\n",
+    "plt.imshow(dynam_dark_map, vmin=vmin, vmax=vmax, interpolation='nearest');"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 2",
+   "language": "python",
+   "name": "python2"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/mica/version.py
+++ b/mica/version.py
@@ -14,7 +14,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '3.5.4'
+version = '3.6'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,11 @@ New BSD/3-clause BSD License
 Copyright (c) 2012 Smithsonian Astrophysical Observatory
 All rights reserved."""
 
+try:
+    from testr.setup_helper import cmdclass
+except ImportError:
+    cmdclass = {}
+
 setup(name='mica',
       description='Mica aspects archive',
       version=version,
@@ -22,7 +27,7 @@ setup(name='mica',
       packages=['mica', 'mica.archive', 'mica.archive.tests', 'mica.archive.aca_dark',
                 'mica.vv', 'mica.vv.tests',
                 'mica.starcheck', 'mica.catalog', 'mica.report', 'mica.web',
-                'mica.stats'],
+                'mica.stats', 'mica.archive.tests'],
       package_data={'mica.web': ['templates/*/*.html', 'templates/*.html']},
       tests_require=['pytest'],
       cmdclass=cmdclass,


### PR DESCRIPTION
Provide a complementary way to `get_slot_data()` of getting ACA L0 image data.

To do:

- [x] Narrative docs
- [x] Tests
- [x] Remove `main()` stub