### PR TITLE
Star history tweaks

### DIFF
--- a/mica/web/templates/mica/star_hist.html
+++ b/mica/web/templates/mica/star_hist.html
@@ -57,7 +57,6 @@ table.pcad {border-spacing: 5px;}
       </div>
 </form>
 
-{% if has_hist %}
 {% if acq_table %}
 <H3>Acquisition History</H3>
 <TABLE class='pcad' border=1>
@@ -118,6 +117,7 @@ table.pcad {border-spacing: 5px;}
 </tr>
 {% endfor %}
 </TABLE>
+{% endif %}
 {% if acq_table %}
 Notes: In the acquisition history table, "dy (corr)" and "dz (corr)" are the offset from
 the expected/commanded position in arcsecs based on the star positions after correction
@@ -125,9 +125,7 @@ the expected/commanded position in arcsecs based on the star positions after cor
 the AGASC magnitude.
 {% endif %}
 
-{% endif %}
-
-
+{% if star_info %}
 <div class="border">
 <H1>AGASC info</H1>
 <TABLE border=1>
@@ -155,13 +153,10 @@ the AGASC magnitude.
 </TD></TR>
 </TABLE>
 </div>
-
-
-
-{% else %}
-{% if agasc_id != '' %}
-<H3>No acq or guide history for star :{{ agasc_id }}:</H3>
 {% endif %}
+
+{% if star_info|length == 0 %}
+<H3>No AGASC 1.6 entry for star :{{ agasc_id }}:</H3>
 {% endif %}
 
 {% endblock %}

--- a/mica/web/templates/mica/star_hist.html
+++ b/mica/web/templates/mica/star_hist.html
@@ -127,7 +127,7 @@ the AGASC magnitude.
 
 {% if star_info %}
 <div class="border">
-<H1>AGASC info</H1>
+<H3>AGASC info</H3>
 <TABLE border=1>
 <TR><TD WIDTH="30%" VALIGN="TOP">
 <TABLE>

--- a/mica/web/templates/mica/star_hist.html
+++ b/mica/web/templates/mica/star_hist.html
@@ -76,7 +76,9 @@ table.pcad {border-spacing: 5px;}
 {% for acq in acq_table %}
 <tr>
 <td>{{ acq.date }}</td>
-<td>{{ acq.obsid }}</td>
+<td><a href="https://icxc.harvard.edu/aspect/mica_reports/
+{{ acq.obsid|stringformat:'05d'|slice:'0:2' }}/{{ acq.obsid|stringformat:'05d' }}
+/"> {{ acq.obsid }}</a></td>
 <td>{{ acq.obi }}</td>
 <td>{{ acq.type }}</td>
 <td>{{ acq.slot }}</td>
@@ -107,7 +109,9 @@ table.pcad {border-spacing: 5px;}
 {% for gui in gui_table %}
 <tr>
 <td>{{ gui.date }}</td>
-<td>{{ gui.obsid }}</td>
+<td><a href="https://icxc.harvard.edu/aspect/mica_reports/
+{{ gui.obsid|stringformat:'05d'|slice:'0:2' }}/{{ gui.obsid|stringformat:'05d' }}
+/"> {{ gui.obsid }}</a></td>
 <td>{{ gui.obi }}</td>
 <td>{{ gui.type }}</td>
 <td>{{ gui.slot }}</td>

--- a/mica/web/views.py
+++ b/mica/web/views.py
@@ -67,8 +67,6 @@ class StarHistView(BaseView, TemplateView):
                 context['star_info'] = []
                 pass
             acq_table, gui_table = mica.web.star_hist.get_star_stats(agasc_id, start, stop)
-            if len(acq_table) or len(gui_table):
-                context['has_hist'] = 1
             if len(acq_table):
                 context['acq_table'] = acq_table
             if len(gui_table):


### PR DESCRIPTION
Star history tweaks for #101 

Make some minor updates to the mica.web star history app.  These changes set the view to show the AGASC info for a star even if that star has no acquisition or guide history, change the size of a displayed header, and set the obsid string (for any previous acquisitions or use as a guide star) to be a link to the mica report web page. 