### PR TITLE
Remove extra empty lines between warnings in report

### DIFF
--- a/templates/report.html
+++ b/templates/report.html
@@ -176,9 +176,11 @@ obs.mp_starcat_time, obs.mp_starcat_vcdu_cnt) -}}
 </PRE>
 {% endif %}
 
-{% for warn in sc['warnings'] %}{% if warn['idx'] is not none %}<PRE>{{- "WARNING: [%2s] %s. %s"|format(
-warn['idx'], warn['warning_type'], warn['warning']) }}
-{% else %}{{- "WARNING: %s"|format(warn['warning']) }}{% endif %}</PRE>{% endfor %}
+<PRE>{% for warn in sc['warnings'] %}
+{% if warn['idx'] is not none %}{{- "WARNING: [%2s] %s. %s"|format(warn['idx'], warn['warning_type'], warn['warning'])}}{% else -%}
+{{- "WARNING: %s"|format(warn['warning']) -}}{% endif -%}
+{% endfor %}
+</PRE>
 
 {% if pred_temp is not none and temps is not none %}
 <PRE>


### PR DESCRIPTION
Remove extra empty lines between warnings in report

**Old:**
![extra_space](https://cloud.githubusercontent.com/assets/791508/24267545/fd9a33ec-0fe0-11e7-865b-6905d18df58c.png)

**New:**
![fix_space](https://cloud.githubusercontent.com/assets/791508/24267551/031e4eca-0fe1-11e7-8ba5-c2176d38056b.png)

