### PR TITLE
Replace shell "find" with os.walk

### DIFF
--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -107,7 +107,7 @@ def prune_dirs(dirs, regex):
 def get_new_starcheck_files(rootdir, mtime=0):
     """
     Look for starcheck.txt files in a a given top-level SOT MP directory
-    and return those with modification times after the optional supplied 'mtime'.
+    and return those with modification times at or after the optional supplied 'mtime'.
     """
     logger.info("Getting new starcheck.txt files from {}".format(rootdir))
     starchecks = []
@@ -127,7 +127,7 @@ def get_new_starcheck_files(rootdir, mtime=0):
             while dirs:
                 dirs.pop()
     starchecks_with_times = [{'file': st, 'mtime': os.path.getmtime(st)}
-                             for st in starchecks if os.path.getmtime(st) > mtime]
+                             for st in starchecks if os.path.getmtime(st) >= mtime]
     starchecks_with_times = sorted(starchecks_with_times, key=itemgetter('mtime'))
     return starchecks_with_times
 

--- a/mica/starcheck/starcheck.sql
+++ b/mica/starcheck/starcheck.sql
@@ -1,6 +1,7 @@
 create table starcheck_id
 (id             int             not null,
 dir             varchar(20)     not null,
+mtime           float           not null,
 primary key (id)
 );
 
@@ -100,7 +101,7 @@ pred_ccd_temp float,
 CONSTRAINT fk_spt_id FOREIGN KEY (sc_id) REFERENCES starcheck_id (id)
 );
 
-
+CREATE INDEX mtime_idx on starcheck_id(mtime);
 CREATE INDEX cat_id_idx on starcheck_catalog(sc_id);
 CREATE INDEX cat_time_idx on starcheck_catalog(mp_starcat_time);
 CREATE INDEX id_dir_idx on starcheck_id(dir);


### PR DESCRIPTION
Replace shell "find" with os.walk in starcheck ingest

This code was set to try to find and ingest "new" starcheck.txt files using a Linux shell
"find" command set to find only files newer than the last ingested file. The time of the
last ingested file was stored by updating *another* file with that file's mod or change
time. The "find" command syntax was ugly, doing this in the shell was also not pretty, and
using a separate tracking file added a place where this could go wrong. This commit adds
the file mod time to the database (so an external tracking file isn't needed) and then
uses os.walk to get files and their mod times to include or exclude them from an update.
The os.walk code is borrowed from kadi.events.orbit_funcs .

The new P_ACQ column requires a database rebuild anyway, and it looks like the "find" command
is responding a bit differently than it has in the past (not sure if files in /data/mpcrit1/mplog have had
permissions changes more recent than their last mod time), so this would be good to just get done now.