### PR TITLE
Parse maneuver end date/time if in starcheck output

### DIFF
--- a/mica/starcheck/starcheck.sql
+++ b/mica/starcheck/starcheck.sql
@@ -42,6 +42,7 @@ target_Q3       float,
 target_Q4       float,
 mp_targquat_time	varchar(25),
 mp_targquat_vcdu_cnt int,
+end_date varchar(25),
 CONSTRAINT fk_sm_id FOREIGN KEY (sc_id) REFERENCES starcheck_id (id)
 );
 


### PR DESCRIPTION
This PR is meant to accompany https://github.com/sot/starcheck/pull/190 to parse the new maneuver end times in starcheck.

```
OBSID: 53272  
RA, Dec, Roll (deg):   163.000000   -20.000000    89.145487
BACKSTOP GUIDE_SUMM OR MANVR DOT MAKE_STARS TLR 

MP_TARGQUAT at 2013:302:14:59:33.091 (VCDU count = 6607454)
  Q1,Q2,Q3,Q4: -0.16732482  0.81354749  0.37632263  0.41051696
  MANVR: Angle= 103.97 deg  Duration= 2046 sec  Slew err= 74.3
  MANVR: Ends= 2013:302:15:33:34.000

MP_TARGQUAT at 2013:302:15:33:59.324 (VCDU count = 6615517)
  Q1,Q2,Q3,Q4: -0.02018249  0.70184443  0.67581851  0.22422401
  MANVR: Angle=  45.93 deg  Duration= 1274 sec  Slew err= 57.7
  MANVR: Ends= 2013:302:15:55:08.000

MP_STARCAT at 2013:302:15:34:00.967 (VCDU count = 6615523)
```
Eventually, we should stop parsing starcheck.txt files altogether, but in the meantime, if the format changes we need these silly little updates in the parser.  This update is a little more extensive in the changes in the parsing because the old code was using the `MANVR: Angle` line to define the end of a maneuver.  This change just splits the maneuver section of the report into individual maneuvers (if needed for a segmented maneuver) and then assumes that we are done parsing a maneuver when we run out of lines to process.