### PR TITLE
Add a configurable start time for ingest of starcheck.txt files in the database

### DIFF
--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -91,7 +91,7 @@ def get_options():
     parser.add_argument("--mp-top-level",
                         help="top level SOT MP dir")
     parser.add_argument("--start",
-                        help="update database with starcheck files after this strt time")
+                        help="update database with starcheck files after this start time")
     opt = parser.parse_args()
     return opt
 

--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -90,6 +90,8 @@ def get_options():
                         help="server or file for database")
     parser.add_argument("--mp-top-level",
                         help="top level SOT MP dir")
+    parser.add_argument("--start",
+                        help="update database with starcheck files after this strt time")
     opt = parser.parse_args()
     return opt
 
@@ -149,9 +151,11 @@ def update(config=None):
     else:
         db = Ska.DBI.DBI(dbi='sqlite', server=config['starcheck_db']['server'])
         max_mtime = db.fetchone("select max(mtime) as mtime from starcheck_id")
-        if max_mtime is not None:
+        if max_mtime is not None and 'start' not in config:
             last_starcheck_mtime = max_mtime['mtime']
-
+    # if a start time is explicitly requested, override 0 or last database value
+    if 'start' in config:
+        last_starcheck_mtime = DateTime(config['start']).unix
     starchecks_with_times = get_new_starcheck_files(config['mp_top_level'],
                                                     mtime=last_starcheck_mtime)
 

--- a/mica/starcheck/tests/make_database.py
+++ b/mica/starcheck/tests/make_database.py
@@ -11,12 +11,9 @@ mica.common.MICA_ARCHIVE = TESTDIR
 import mica.starcheck.process
 
 # Just ingest files from the last couple of weeks or so
-# This still uses the silly find files newer than this other file method, so
-# set the time stamp on that reference file
-if not os.path.exists(os.path.join(TESTDIR, 'starcheck')):
-    os.makedirs(os.path.join(TESTDIR, 'starcheck'))
-bash("touch -d {} {}".format(DateTime(-15).iso, mica.starcheck.process.FILES['touch_file']))
-# And just check that the update script didn't raise any exceptions
-mica.starcheck.process.update()
+# And just check (implicitly) that the update script didn't raise any exceptions
+config = mica.starcheck.process.DEFAULT_CONFIG
+config['start'] = DateTime() - 30
+mica.starcheck.process.update(config)
 # Cleanup manually
 bash("rm -r {}".format(TESTDIR))


### PR DESCRIPTION
Add a configurable start time for ingest of starcheck.txt files

#108 removed the need for the silly "touch file".  That was a file manually set with a timestamp and it was used in combination with an option to the shell "find" command to find files newer that that timestamp matching the pattern.  That was used to get "new" starcheck.txt files to update the database.  It was also how one could define a more recent time to, say, just get some recent files to  make a quick testing database.  This PR just adds a "start" time to the utility to have that option for testing.  Theoretically, I could also have just made a small /data/mpcrit1/ or used some similar technique to get just a handful of files for testing.