### PR TITLE
Address minor issues in #110

### DIFF
--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -153,7 +153,7 @@ def update(config=None):
         max_mtime = db.fetchone("select max(mtime) as mtime from starcheck_id")
         if max_mtime is not None:
             last_starcheck_mtime = max_mtime['mtime']
-    # if a start time is explicitly requested, override 0 or last database value
+    # If a start time is explicitly requested, override 0 or last database value
     if 'start' in config:
         last_starcheck_mtime = DateTime(config['start']).unix
     starchecks_with_times = get_new_starcheck_files(config['mp_top_level'],

--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -151,7 +151,7 @@ def update(config=None):
     else:
         db = Ska.DBI.DBI(dbi='sqlite', server=config['starcheck_db']['server'])
         max_mtime = db.fetchone("select max(mtime) as mtime from starcheck_id")
-        if max_mtime is not None and 'start' not in config:
+        if max_mtime is not None:
             last_starcheck_mtime = max_mtime['mtime']
     # if a start time is explicitly requested, override 0 or last database value
     if 'start' in config:


### PR DESCRIPTION
Address minor issues in #110

Put in fixes suggested in review on #110 (updates for starcheck_parser to add a 'start' time for testing) that didn't get in due to speedy merging.  Fixes includes slightly simplifying the logic in on how a supplied 'start' time is handled and updating a comment. The larger issue noted in that review, specifically, the over-configuration problem, is temporarily offloaded to a new issue #111 