### PR TITLE
Handle a few missing obsids in acq stats

### DIFF
--- a/mica/stats/acq_stats.py
+++ b/mica/stats/acq_stats.py
@@ -442,7 +442,7 @@ def _get_obsids_to_update(check_missing=False):
 
 
 def calc_stats(obsid):
-    obspar = mica.archive.obspar.get_obspar(obsid)
+    obspar = mica.archive.obspar.get_obspar(obsid, version='last')
     if not obspar:
         raise ValueError("No obspar for {}".format(obsid))
     manvr = None

--- a/mica/stats/acq_stats.py
+++ b/mica/stats/acq_stats.py
@@ -516,7 +516,7 @@ def calc_stats(obsid):
                                               mp_dir='/2007/MAY2807/oflsb/')
         else:
             raise ValueError("Problem looking up starcheck for {}".format(obsid))
-    if 'cat' not in starcheck or not len(starcheck['cat']):
+    if starcheck is None or 'cat' not in starcheck or not len(starcheck['cat']):
         raise ValueError('No starcheck catalog found for {}'.format(
                 manvr.get_obsid()))
     starcat_time = DateTime(starcheck['cat']['mp_starcat_time'][0]).secs


### PR DESCRIPTION
Handle a few missing obsids in acq stats

This fixes one bug introduced in https://github.com/sot/mica/commit/495c48a90fd48a53c8a29d3b36fa0357b70d045a .  Use of the new starcheck catalog fetcher can return None, which was not anticipated by the handling.  	2bbf4b9 helps to handle that case of no star catalog. 2e3db32 uses the most recent obspar to get times instead of the "default" obspar.  All use of the obspar should really be removed from this code in the future.
