### PR TITLE
Use chandra aca dark model (instead of mica version)

### DIFF
--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -154,7 +154,7 @@ def update(config=None):
         if max_mtime is not None:
             last_starcheck_mtime = max_mtime['mtime']
     # If a start time is explicitly requested, override 0 or last database value
-    if 'start' in config:
+    if 'start' in config and config['start'] is not None:
         last_starcheck_mtime = DateTime(config['start']).unix
     starchecks_with_times = get_new_starcheck_files(config['mp_top_level'],
                                                     mtime=last_starcheck_mtime)

--- a/mica/stats/acq_stats.py
+++ b/mica/stats/acq_stats.py
@@ -545,8 +545,7 @@ def calc_stats(obsid):
                                       time-250,
                                       time+250).vals)
     warm_threshold = 100.0
-    warm_frac = mica.archive.aca_dark.dark_model.get_warm_fracs(
-        warm_threshold, time, ccd_temp)
+    warm_frac = dark_model.get_warm_fracs(warm_threshold, time, ccd_temp)
     temps = {'ccd_temp': ccd_temp, 'n100_warm_frac': warm_frac}
     return obsid_info, acq_stats, star_info, catalog, temps
 

--- a/mica/version.py
+++ b/mica/version.py
@@ -14,7 +14,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '3.9.0'
+version = '3.9.1'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])


### PR DESCRIPTION
Use chandra aca dark model (instead of mica version)

It looks like this was half-done (chandra_aca.dark_model added in imports but code to get_warm_fracs still using the mica.archive version).  This should go as another bugfix.