### PR TITLE
Get osol from archive when fetching asp1

### DIFF
--- a/mica/archive/asp_l1.py
+++ b/mica/archive/asp_l1.py
@@ -34,7 +34,7 @@ CONFIG = dict(data_root=os.path.join(MICA_ARCHIVE, 'asp1'),
               full='asp1',
               filecheck=False,
               cols=ARCHFILES_HDR_COLS,
-              content_types=['ASPQUAL', 'ASPSOL', 'ACADATA', 'GSPROPS',
+              content_types=['OBCSOL', 'ASPQUAL', 'ASPSOL', 'ACADATA', 'GSPROPS',
                              'GYRODATA', 'KALMAN', 'ACACAL', 'ACACENT',
                              'FIDPROPS', 'GYROCAL', 'ACA_BADPIX'])
 

--- a/mica/archive/obsid_archive.py
+++ b/mica/archive/obsid_archive.py
@@ -461,6 +461,10 @@ class ObsArchive:
             arc5.sendline("obi=%d" % minobi)
         arc5.sendline("version=%s" % version)
         arc5.sendline("get %s" % config['full'])
+        # if we're getting ASP1, explicitly get OSOL as well because it doesn't
+        # show up unless you ask for it.
+        if config['full'] == "asp1":
+            arc5.sendline("get asp1{obcsol}")
         # get the log too
         arc5.sendline("dataset=pipelog")
         arc5.sendline("go")


### PR DESCRIPTION
Get osol from CXCDS archive when fetching other asp1 content.

This appears to not be included with the standard "get asp1", so it needs an additional "get".