### PR TITLE
In V&V, handle case of uncommanded image window during Kalman

### DIFF
--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -1038,6 +1038,9 @@ class AspectInterval(object):
             #    logger.warn("No image data to identify missing slot {}".format(slot))
             #    logger.warn("Skipping slot")
             #missing_types.append(stype)
+            if slot not in ocat_stars['slot']:
+                logger.info("Missing slot not in OCAT.  Skipping...")
+                continue
             ocat_info = ocat_stars[ocat_stars['slot'] == slot][0]
             if ocat_info['type'] == 3:
                 logger.info("Missing slot is MONITOR.  Skipping...")

--- a/mica/vv/tests/test_vv.py
+++ b/mica/vv/tests/test_vv.py
@@ -40,3 +40,7 @@ def test_run_vv_multi_interval():
 
 def test_run_vv_omitted_fid():
     process.get_arch_vv(18978, version='last')
+
+def test_run_vv_7_track_slots():
+    # Run on an obsid with only 7 slots *commanded* during Kalman
+    process.get_arch_vv(19847, version='last')


### PR DESCRIPTION
In V&V, handle case of uncommanded image window during Kalman.  The previous code assumed that any missing slots had entries in the ocat stars table.  This change checks to see if missing slots have entries in the table.  If a slot has no entry, it is just skipped.  This is designed for catalogs that are commanded with fewer than 8 used image windows during Kalman.