### PR TITLE
Smaller markers on just the yz v&v plots

### DIFF
--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -673,8 +673,8 @@ class Obi(object):
             ayz = fig.add_axes([.05, .7, .20, .20], aspect='equal')
             plot_dict['all'] = fig
         axes['yz'] = ayz
-        ayz.plot(dy[ok], dz[ok], 'g.')
-        ayz.plot(dy[bad], dz[bad], 'r.')
+        ayz.plot(dy[ok], dz[ok], 'g.', markersize=1)
+        ayz.plot(dy[bad], dz[bad], 'r.', markersize=1)
         ayz.grid()
         plt.setp(ayz.get_yticklabels(), fontsize=labelfontsize)
         plt.setp(ayz.get_xticklabels(), fontsize=labelfontsize)
@@ -705,8 +705,8 @@ class Obi(object):
         else:
             ayzf = fig.add_axes([.05, .25, .20, .20], aspect='equal')
         axes['yz_fixed'] = ayzf
-        ayzf.plot(dy[ok], dz[ok], 'g.')
-        ayzf.plot(dy[bad], dz[bad], 'r.')
+        ayzf.plot(dy[ok], dz[ok], 'g.', markersize=1)
+        ayzf.plot(dy[bad], dz[bad], 'r.', markersize=1)
         ayzf.grid()
         plt.setp(ayzf.get_yticklabels(), fontsize=labelfontsize)
         plt.setp(ayzf.get_xticklabels(), fontsize=labelfontsize)


### PR DESCRIPTION
Use smaller markers on the YZ V&V plots to see the shape of the distribution. 

At some point a "heat map" style density plot for these could also make sense.