### PR TITLE
Handle case of obsid with multiple dwells

### DIFF
--- a/mica/stats/acq_stats.py
+++ b/mica/stats/acq_stats.py
@@ -451,9 +451,9 @@ def calc_stats(obsid):
     try:
         manvrs = events.manvrs.filter(obsid=obsid, n_dwell__gt=0)
         dwells = events.dwells.filter(obsid=obsid)
-        if manvrs.count() and dwells.count() == 1:
-            manvr = manvrs[0]
-            dwell = dwells[0]
+        # Use the last manvr and the first dwell
+        manvr = manvrs[manvrs.count() - 1]
+        dwell = dwells[0]
     except ValueError:
         multi_manvr = events.manvrs.filter(start=obspar['tstart'] - 10000,
                                            stop=obspar['tstart'] + 10000)

--- a/mica/stats/tests/test_acq_stats.py
+++ b/mica/stats/tests/test_acq_stats.py
@@ -6,6 +6,9 @@ from .. import acq_stats
 
 def test_calc_stats():
     acq_stats.calc_stats(17210)
+    acq_stats.calc_stats(15175)
+    acq_stats.calc_stats(4911)
+    acq_stats.calc_stats(19386)
 
 
 def test_make_acq_stats():


### PR DESCRIPTION
Handle case of obsid with multiple dwells.  Obsids 15175 and 4911 have multiple dwells and were skipped in the previous version of this code.    Obsids have been added to test code. 