### PR TITLE
Filter tracked guide star data for reasonable stats

### DIFF
--- a/mica/stats/guide_stats.py
+++ b/mica/stats/guide_stats.py
@@ -306,9 +306,9 @@ def calc_gui_stats(start, stop, data, times, star_info):
                     data['AOACFCT{}'.format(slot)] == 'TRAK')))
 
 
-        # reduce this to just the samples that don't have IR or SP set
-        kal = trak[ok_flags]
-
+        # reduce this to just the samples that don't have IR or SP set and are in Kalman on guide stars
+        kal = trak[ok_flags & (trak['AOACASEQ'] == 'KALM') & (trak['AOPCADMD'] == 'NPNT')
+                   & (trak['AOFSTAR'] == 'GUID')]
         dy = kal['dy{}'.format(slot)]
         dz = kal['dz{}'.format(slot)]
         # cheating here and ignoring spherical trig

--- a/mica/stats/tests/test_guide_stats.py
+++ b/mica/stats/tests/test_guide_stats.py
@@ -7,6 +7,11 @@ from .. import guide_stats
 def test_calc_stats():
     guide_stats.calc_stats(17210)
 
+def test_calc_stats_with_bright_trans():
+    s = guide_stats.calc_stats(17472)
+    # Assert that the std on the slot 7 residuals are reasonable
+    # even in this obsid that had a transition to BRIT
+    assert s[1][7]['dr_std'] < 1
 
 def test_make_gui_stats():
     """


### PR DESCRIPTION
Filter the tracked data used to calculate the star residual stats to only include samples in NPNT, KALM, and while tracking GUID stars.