### PR TITLE
Fix inconsistencies in queried starcheck database for observations without star catalogs

### DIFF
--- a/mica/starcheck/starcheck_parser.py
+++ b/mica/starcheck/starcheck_parser.py
@@ -149,7 +149,7 @@ def get_starcat_header(obs_text):
 
 
 def get_manvrs(obs_text):
-    man_search = re.search("(MP_TARGQUAT((.*)\n){2,}\n)MP_STARCAT", obs_text)
+    man_search = re.search("(MP_TARGQUAT((.*)\n){2,}\n)", obs_text)
     if not man_search:
         return {}
     manvr_block = man_search.group(1)

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -123,6 +123,11 @@ def test_obsid_catalog_fetch():
             assert len(sc['cat']) == t['n_cat_entries']
         if t['obsid'] == 62668:
             assert sc is None
+    # review a dark current replica obsid
+    dcdir, dcstatus, dcdate = starcheck.get_mp_dir(49961)
+    assert dcdir == '/2017/JUL0317/oflsb/'
+    assert dcstatus == 'no starcat'
+    assert dcdate is None
 
 
 def test_monitor_fetch():


### PR DESCRIPTION
Fix inconsistencies in queried starcheck database for observations without star catalogs.  The fixes include:

- ingesting maneuver information for observations with maneuver but without star catalog in starcheck output
- explicitly handling the case of an observation with a None/NULL entry for the star catalog time