### PR TITLE
Fix update() bug introduced by ec6f166

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -843,7 +843,7 @@ def update():
 
     recent_obs = np.unique(fetch_states(start=DateTime(-7), vals=['obsid'])['obsid'])
     for obs in recent_obs:
-        process_obsids([obs['obsid']])
+        process_obsids([obs])
 
 
 


### PR DESCRIPTION
The update to fetch cmd_states from fetch_states instead of via the Sybase table introduced a tiny bug/IndexError.  

The update() code is not directly tested by module tests.