### PR TITLE
Minor fixes to remove/fix some displayed warnings

### DIFF
--- a/mica/archive/asp_l1.py
+++ b/mica/archive/asp_l1.py
@@ -195,7 +195,7 @@ def get_atts_from_files(asol_files, acal_files, aqual_files, filter=True):
     for asol_f, acal_f, aqual_f in zip(asol_files, acal_files, aqual_files):
         asol = Table.read(asol_f)
         acal = Table.read(acal_f)
-        aqual = Table.read(aqual_f)
+        aqual = Table.read(aqual_f, hdu=1)
         # Check that the time ranges match from the fits headers (meta in the table)
         if not np.allclose(np.array([asol.meta['TSTART'], asol.meta['TSTOP']]),
                            np.array([acal.meta['TSTART'], acal.meta['TSTOP']]),

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -3,8 +3,6 @@ from __future__ import division, print_function
 import os
 import sys
 import warnings
-# Import this before kadi events skips the deprecation warning
-import compiler
 
 import re
 import logging


### PR DESCRIPTION
Minor fixes to remove/fix some displayed warnings
This cleans up an AstropyUserWarning and a DeprecationWarning when running the mica built-in tests.