### PR TITLE
Change use of manvr.nman_start to get star catalogs for a few obsids

### DIFF
--- a/mica/starcheck/starcheck.py
+++ b/mica/starcheck/starcheck.py
@@ -153,7 +153,13 @@ def get_starcheck_catalog_at_date(date, starcheck_db=None, timelines_db=None):
         # If we have a dwell from kadi, use it to search for commanding
         dwell = dwells[0]
         dwell_start = dwell.start
-        start_cat_search = dwell.manvr.nman_start if dwell.manvr.n_dwell > 1 else dwell.get_previous().stop
+        # Try to use the beginning of the previous nman period to define when the catalog
+        # should have been commanded.  If there are multiple dwells for attitude, try to
+        # use nman_start if available.
+        if dwell.manvr.n_dwell > 1 and dwell.manvr.nman_start is not None:
+            start_cat_search = dwell.manvr.nman_start
+        else:
+            start_cat_search = dwell.get_previous().stop
 
     timelines = timelines_db.fetchall(
             """select * from timeline_loads where scs < 131


### PR DESCRIPTION
This let's get_starcheck_catalog_at_data succeed reasonably for a few dwells that have kadi manvrs that don't have nman_start defined and have more than one dwell for the maneuver.  The bits of code in this section were intended to help get the right catalog for the no-maneuver cases (multiple aspect intervals but same obsid), but it looks like a side effect was that some no-maneuver cases that *also* have segmented maneuvers don't work.  This is a small number of observations.

