### PR TITLE
Fix bug in parsing/ingest of manvrs

### DIFF
--- a/mica/starcheck/starcheck_parser.py
+++ b/mica/starcheck/starcheck_parser.py
@@ -184,7 +184,9 @@ def get_manvrs(obs_text):
                                        end_date=angle_re.group(5)))
                 if 'target_Q1' not in curr_manvr:
                     raise ValueError("No Q1,Q2,Q3,Q4 line found when parsing starcheck.txt")
-        manvrs.append(curr_manvr)
+        # If there is a real manvr, append to list
+        if ('mp_targquat_time' in curr_manvr) and ('target_Q1' in curr_manvr):
+            manvrs.append(curr_manvr)
     for idx, manvr in enumerate(manvrs):
         manvr['instance'] = idx
     return manvrs

--- a/mica/version.py
+++ b/mica/version.py
@@ -15,7 +15,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '3.13'
+version = '3.13.1'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])


### PR DESCRIPTION
Code that was intended to support not-breaking on intermediate maneuvers has a regex bug that is causing extra empty maneuvers to get in to the data structure.  This is breaking ingest.  This small bugfix doesn't fix the regex, but just stops the empty manvr entries from ending up in the data structure.