### PR TITLE
Add hdu to asol and acal reads in get_atts_from_files

### DIFF
--- a/mica/archive/asp_l1.py
+++ b/mica/archive/asp_l1.py
@@ -194,8 +194,8 @@ def get_atts_from_files(asol_files, acal_files, aqual_files, filter=True):
     time_chunks = []
     records = []
     for asol_f, acal_f, aqual_f in zip(asol_files, acal_files, aqual_files):
-        asol = Table.read(asol_f)
-        acal = Table.read(acal_f)
+        asol = Table.read(asol_f, hdu=1)
+        acal = Table.read(acal_f, hdu=1)
         aqual = Table.read(aqual_f, hdu=1)
         # Check that the time ranges match from the fits headers (meta in the table)
         if not np.allclose(np.array([asol.meta['TSTART'], asol.meta['TSTOP']]),


### PR DESCRIPTION
Add hdu to asol and acal reads in get_atts_from_files

This is intended to fix warnings when run in ska3:
```
chandra_aca/tests/test_residuals.py::test_obc_centroids
  /proj/sot/ska3/flight/arch/x86_64-linux_CentOS-5/lib/python3.6/site-packages/astropy/io/fits/connect.py:110: AstropyUserWarning: hdu= was not specified but multiple tables are present, reading in first available table (hdu=1)
    AstropyUserWarning)

```
(These tests are actually in chandra_aca, but this asol reading code is getting hit from there)
