### PR TITLE
Fix npnt_tstop typo in guide stats database

### DIFF
--- a/mica/stats/guide_stats.py
+++ b/mica/stats/guide_stats.py
@@ -42,7 +42,7 @@ GUIDE_COLS = {
         ('obsid', 'int'),
         ('obi', 'int'),
         ('kalman_tstart', 'float'),
-        ('npnt_tstop', 'S21'),
+        ('npnt_tstop', 'float'),
         ('kalman_datestart', 'S21'),
         ('npnt_datestop', 'S21'),
         ('revision', 'S15')],


### PR DESCRIPTION
npnt_tstop is a float and npnt_datestop is a string.  npnt_tstop was set with a string type and ingested that way, so the database will need a rebuild to be consistent.