### PR TITLE
Skip tests based on existence of parts of mica archive

### DIFF
--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -2,18 +2,20 @@
 """
 Basic functionality and regression tests for ACA dark cal module.
 """
-
+import os
 import numpy as np
 import pytest
 
 from ..aca_dark import dark_cal
 from chandra_aca.aca_image import ACAImage
 
+HAS_DARK_ARCHIVE = os.path.exists(dark_cal.MICA_FILES['dark_cals_dir'].abs)
 
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_date_to_dark_id():
     assert dark_cal.date_to_dark_id('2011-01-15T12:00:00') == '2011015'
 
-
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_dark_id_to_date():
     assert dark_cal.dark_id_to_date('2011015') == '2011:015'
 
@@ -25,13 +27,13 @@ def test_dark_temp_scale():
     scale = dark_cal.dark_temp_scale(-10., -14, scale_4c=2.0)
     assert scale == 0.5  # Should be an exact match
 
-
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_get_dark_cal_id():
     assert dark_cal.get_dark_cal_id('2007:008', 'nearest') == '2007006'
     assert dark_cal.get_dark_cal_id('2007:008', 'before') == '2007006'
     assert dark_cal.get_dark_cal_id('2007:008', 'after') == '2007069'
 
-
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 @pytest.mark.parametrize('aca_image', [True, False])
 def test_get_dark_cal_image(aca_image):
     image = dark_cal.get_dark_cal_image('2007:008', aca_image=aca_image)
@@ -44,7 +46,7 @@ def test_get_dark_cal_image(aca_image):
     else:
         assert type(image) is np.ndarray
 
-
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 @pytest.mark.parametrize('aca_image', [True, False])
 def test_get_dark_cal_props(aca_image):
     props = dark_cal.get_dark_cal_props('2007:008')
@@ -57,7 +59,7 @@ def test_get_dark_cal_props(aca_image):
     assert props['image'].shape == (1024, 1024)
     assert type(props['image']) is (ACAImage if aca_image else np.ndarray)
 
-
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_get_dark_cal_props_table():
     props = dark_cal.get_dark_cal_props_table('2007:001', '2008:001')
     assert np.allclose(props['eb'], [24.6, 25.89, 51.13, 1.9])

--- a/mica/archive/tests/test_aca_hdr3.py
+++ b/mica/archive/tests/test_aca_hdr3.py
@@ -2,12 +2,15 @@
 """
 Basic functionality and regression tests for ACA hdr3 (diagnostic) telemetry.
 """
-
+import os
+import pytest
 import numpy as np
 
 from .. import aca_hdr3
 
+HAS_L0_ARCHIVE = os.path.exists(os.path.abspath(aca_hdr3.aca_l0.CONFIG['data_root']))
 
+@pytest.mark.skipif('not HAS_L0_ARCHIVE', reason='Test requires L0 archive')
 def test_MSIDset():
     """
     Read all available MSIDs into a single MSIDset.  Use the empirically determined

--- a/mica/archive/tests/test_aca_hdr3.py
+++ b/mica/archive/tests/test_aca_hdr3.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from .. import aca_hdr3
 
-HAS_L0_ARCHIVE = os.path.exists(os.path.abspath(aca_hdr3.aca_l0.CONFIG['data_root']))
+HAS_L0_ARCHIVE = os.path.exists(aca_hdr3.aca_l0.CONFIG['data_root'])
 
 @pytest.mark.skipif('not HAS_L0_ARCHIVE', reason='Test requires L0 archive')
 def test_MSIDset():

--- a/mica/archive/tests/test_aca_l0.py
+++ b/mica/archive/tests/test_aca_l0.py
@@ -7,7 +7,7 @@ import numpy as np
 from mica.archive import aca_l0, asp_l1
 from Ska.Numpy import interpolate
 
-HAS_L0_ARCHIVE = os.path.exists(os.path.abspath(aca_l0.CONFIG['data_root']))
+HAS_L0_ARCHIVE = os.path.exists(aca_l0.CONFIG['data_root'])
 
 @pytest.mark.skipif('not HAS_L0_ARCHIVE', reason='Test requires L0 archive')
 def test_get_l0_images():

--- a/mica/archive/tests/test_aca_l0.py
+++ b/mica/archive/tests/test_aca_l0.py
@@ -1,12 +1,15 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from __future__ import division
-
+import os
+import pytest
 from astropy.table import Table
 import numpy as np
 from mica.archive import aca_l0, asp_l1
 from Ska.Numpy import interpolate
 
+HAS_L0_ARCHIVE = os.path.exists(os.path.abspath(aca_l0.CONFIG['data_root']))
 
+@pytest.mark.skipif('not HAS_L0_ARCHIVE', reason='Test requires L0 archive')
 def test_get_l0_images():
     """
     Do a validation test of get_l0_images:

--- a/mica/archive/tests/test_asp_l1.py
+++ b/mica/archive/tests/test_asp_l1.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
 import numpy as np
 from Quaternion import Quat, normalize
 from Ska.engarchive import fetch
@@ -7,6 +8,7 @@ import pytest
 
 from .. import asp_l1
 
+HAS_L1_ARCHIVE = os.path.exists(os.path.abspath(asp_l1.CONFIG['data_root']))
 
 def compare_obc_and_asol(atts, times, recs, ptol=2, ytol=2, rtol=50):
     """
@@ -45,12 +47,13 @@ def compare_obc_and_asol(atts, times, recs, ptol=2, ytol=2, rtol=50):
         assert np.all(np.abs(drs) < rtol)
 
 
+@pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 @pytest.mark.parametrize("obsid", [14333, 15175, 5438, 2121])
 def test_get_atts_obsid(obsid):
     atts, times, recs = asp_l1.get_atts(obsid=obsid)
     compare_obc_and_asol(atts, times, recs)
 
-
+@pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 def test_get_atts_time():
     start = '2014:001:00:00:00.000'
     stop = '2014:005:00:00:00.000'
@@ -67,7 +70,7 @@ def test_get_atts_time():
         # also assert that the number of ~.25sec samples works out
         assert (len(times[ok]) * .25625) > dwell.dur * .90
 
-
+@pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 def test_get_atts_filter():
     # Obsid 19039 has a momentum dump that shows up in asp_sol_status
     atts, times, recs = asp_l1.get_atts(obsid=19039)

--- a/mica/archive/tests/test_asp_l1.py
+++ b/mica/archive/tests/test_asp_l1.py
@@ -8,7 +8,7 @@ import pytest
 
 from .. import asp_l1
 
-HAS_L1_ARCHIVE = os.path.exists(os.path.abspath(asp_l1.CONFIG['data_root']))
+HAS_L1_ARCHIVE = os.path.exists(asp_l1.CONFIG['data_root'])
 
 def compare_obc_and_asol(atts, times, recs, ptol=2, ytol=2, rtol=50):
     """

--- a/mica/archive/tests/test_obspar.py
+++ b/mica/archive/tests/test_obspar.py
@@ -1,6 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+import pytest
 from .. import obspar
 
+HAS_OBSPAR_ARCHIVE = os.path.exists(os.path.abspath(obspar.CONFIG['data_root']))
+
+@pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires obspar archive')
 def test_get_obsids():
     """
     Test that archive.obspar.get_obsids gets a reasonable set of obsids.

--- a/mica/archive/tests/test_obspar.py
+++ b/mica/archive/tests/test_obspar.py
@@ -3,7 +3,7 @@ import os
 import pytest
 from .. import obspar
 
-HAS_OBSPAR_ARCHIVE = os.path.exists(os.path.abspath(obspar.CONFIG['data_root']))
+HAS_OBSPAR_ARCHIVE = os.path.exists(obspar.CONFIG['data_root'])
 
 @pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires obspar archive')
 def test_get_obsids():

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -10,7 +10,7 @@ import pytest
 
 from .. import starcheck
 
-HAS_SC_ARCHIVE = os.path.exists(os.path.abspath(starcheck.FILES['data_root']))
+HAS_SC_ARCHIVE = os.path.exists(starcheck.FILES['data_root'])
 
 def get_cmd_quat(date):
     date = DateTime(date)

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -74,14 +74,15 @@ def get_trak_cat_from_telem(start, stop, cmd_quat):
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_validate_catalogs_over_range():
     start = '2017:001'
-    stop = '2017:004'
+    stop = '2017:002'
     dwells = events.dwells.filter(start, stop)
     for dwell in dwells:
+        print(dwell)
         telem_quat = get_cmd_quat(dwell.start)
         # try to get the tracked telemetry for 1ks at the beginning of the dwell,
         # or if the dwell is shorter than that, just get the dwell
         cat, telem = get_trak_cat_from_telem(dwell.start,
-                                             np.min([dwell.tstart + 1000, dwell.tstop]),
+                                             np.min([dwell.tstart + 100, dwell.tstop]),
                                              telem_quat)
         sc = starcheck.get_starcheck_catalog_at_date(dwell.start)
         sc_quat = Quat([sc['manvr'][-1]["target_Q{}".format(i)] for i in [1, 2, 3, 4]])
@@ -136,5 +137,5 @@ def test_obsid_catalog_fetch():
 
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_monitor_fetch():
-    mons = starcheck.get_monitor_windows(start='2009:001', stop='2010:001')
-    assert len(mons) == 53
+    mons = starcheck.get_monitor_windows(start='2009:002', stop='2009:007')
+    assert len(mons) == 10

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -1,4 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
 import numpy as np
 from Quaternion import normalize, Quat
 from Chandra.Time import DateTime
@@ -9,6 +10,7 @@ import pytest
 
 from .. import starcheck
 
+HAS_SC_ARCHIVE = os.path.exists(os.path.abspath(starcheck.FILES['data_root']))
 
 def get_cmd_quat(date):
     date = DateTime(date)
@@ -69,6 +71,7 @@ def get_trak_cat_from_telem(start, stop, cmd_quat):
     return cat, telem
 
 
+@pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_validate_catalogs_over_range():
     start = '2017:001'
     stop = '2017:004'
@@ -107,6 +110,7 @@ def test_validate_catalogs_over_range():
                     assert np.abs(cat[slot]['zag'] - trak_sc_slot['zang']) < 5.0
 
 
+@pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_obsid_catalog_fetch():
     tests = [{'obsid': 19990,
               'mp_dir': '/2017/FEB2017/oflsa/',
@@ -130,7 +134,7 @@ def test_obsid_catalog_fetch():
     assert dcstatus == 'no starcat'
     assert dcdate is None
 
-
+@pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_monitor_fetch():
     mons = starcheck.get_monitor_windows(start='2009:001', stop='2010:001')
     assert len(mons) == 53

--- a/mica/stats/tests/test_acq_stats.py
+++ b/mica/stats/tests/test_acq_stats.py
@@ -5,8 +5,8 @@ import pytest
 
 from .. import acq_stats
 
-HAS_OBSPAR_ARCHIVE = os.path.exists(os.path.abspath(
-        acq_stats.mica.archive.obspar.CONFIG['data_root']))
+HAS_OBSPAR_ARCHIVE = os.path.exists(
+        acq_stats.mica.archive.obspar.CONFIG['data_root'])
 
 @pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
 def test_calc_stats():

--- a/mica/stats/tests/test_acq_stats.py
+++ b/mica/stats/tests/test_acq_stats.py
@@ -1,17 +1,21 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import tempfile
 import os
+import pytest
 
 from .. import acq_stats
 
+HAS_OBSPAR_ARCHIVE = os.path.exists(os.path.abspath(
+        acq_stats.mica.archive.obspar.CONFIG['data_root']))
 
+@pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
 def test_calc_stats():
     acq_stats.calc_stats(17210)
     acq_stats.calc_stats(15175)
     acq_stats.calc_stats(4911)
     acq_stats.calc_stats(19386)
 
-
+@pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
 def test_make_acq_stats():
     """
     Save the acq stats for one obsid into a newly-created table

--- a/mica/stats/tests/test_guide_stats.py
+++ b/mica/stats/tests/test_guide_stats.py
@@ -1,19 +1,35 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import tempfile
 import os
+import numpy as np
+import pytest
 
 from .. import guide_stats
 
+HAS_GS_TABLE = os.path.exists(os.path.abspath(guide_stats.TABLE_FILE))
 
+@pytest.mark.skipif('not HAS_GS_TABLE', reason='Test requires guide stats table')
+def test_read_stats():
+    stats = guide_stats.get_stats()
+    slot = stats[(stats['obsid'] == 5438) & (stats['slot'] == 5)][0]
+    np.isclose(slot['dy_std'], 0.16008819321078668)
+    np.isclose(slot['dz_std'], 0.23807435722775061)
+
+HAS_OBSPAR_ARCHIVE = os.path.exists(os.path.abspath(
+        guide_stats.mica.archive.obspar.CONFIG['data_root']))
+
+@pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
 def test_calc_stats():
     guide_stats.calc_stats(17210)
 
+@pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
 def test_calc_stats_with_bright_trans():
     s = guide_stats.calc_stats(17472)
     # Assert that the std on the slot 7 residuals are reasonable
     # even in this obsid that had a transition to BRIT
     assert s[1][7]['dr_std'] < 1
 
+@pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
 def test_make_gui_stats():
     """
     Save the guide stats for one obsid into a newly-created table

--- a/mica/stats/tests/test_guide_stats.py
+++ b/mica/stats/tests/test_guide_stats.py
@@ -6,7 +6,7 @@ import pytest
 
 from .. import guide_stats
 
-HAS_GS_TABLE = os.path.exists(os.path.abspath(guide_stats.TABLE_FILE))
+HAS_GS_TABLE = os.path.exists(guide_stats.TABLE_FILE)
 
 @pytest.mark.skipif('not HAS_GS_TABLE', reason='Test requires guide stats table')
 def test_read_stats():
@@ -15,8 +15,8 @@ def test_read_stats():
     np.isclose(slot['dy_std'], 0.16008819321078668)
     np.isclose(slot['dz_std'], 0.23807435722775061)
 
-HAS_OBSPAR_ARCHIVE = os.path.exists(os.path.abspath(
-        guide_stats.mica.archive.obspar.CONFIG['data_root']))
+HAS_OBSPAR_ARCHIVE = os.path.exists(
+        guide_stats.mica.archive.obspar.CONFIG['data_root'])
 
 @pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
 def test_calc_stats():

--- a/mica/vv/tests/test_vv.py
+++ b/mica/vv/tests/test_vv.py
@@ -6,10 +6,10 @@ from .. import vv
 from .. import process
 from ... import common
 
-HAS_L1_ARCHIVE = os.path.exists(os.path.abspath(process.asp_l1_arch.CONFIG['data_root']))
-HAS_VV_ARCHIVE = (os.path.exists(os.path.abspath(vv.FILES['data_root']))
-                  & os.path.exists(os.path.abspath(vv.FILES['asp1_proc_table']))
-                  & os.path.exists(os.path.abspath(vv.FILES['h5_file'])))
+HAS_L1_ARCHIVE = os.path.exists(process.asp_l1_arch.CONFIG['data_root'])
+HAS_VV_ARCHIVE = (os.path.exists(vv.FILES['data_root'])
+                  & os.path.exists(vv.FILES['asp1_proc_table'])
+                  & os.path.exists(vv.FILES['h5_file']))
 
 @pytest.mark.skipif('not HAS_VV_ARCHIVE', reason='Test requires vv archive')
 def test_get_vv_dir():

--- a/mica/vv/tests/test_vv.py
+++ b/mica/vv/tests/test_vv.py
@@ -1,16 +1,22 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+import pytest
 import numpy as np
 from .. import vv
 from .. import process
 from ... import common
 
+HAS_L1_ARCHIVE = os.path.exists(os.path.abspath(process.asp_l1_arch.CONFIG['data_root']))
+HAS_VV_ARCHIVE = (os.path.exists(os.path.abspath(vv.FILES['data_root']))
+                  & os.path.exists(os.path.abspath(vv.FILES['asp1_proc_table']))
+                  & os.path.exists(os.path.abspath(vv.FILES['h5_file'])))
 
+@pytest.mark.skipif('not HAS_VV_ARCHIVE', reason='Test requires vv archive')
 def test_get_vv_dir():
     obsdir = vv.get_vv_dir(16504)
     assert obsdir == os.path.abspath(os.path.join(common.MICA_ARCHIVE, 'vv/16/16504_v01'))
 
-
+@pytest.mark.skipif('not HAS_VV_ARCHIVE', reason='Test requires vv archive')
 def test_get_vv_files():
     obsfiles = vv.get_vv_files(16504)
     assert sorted(obsfiles)[-1] == os.path.abspath(os.path.join(common.MICA_ARCHIVE,
@@ -21,27 +27,31 @@ def test_get_rms_data():
     dz_rms = data[(data['obsid'] == 16505) & (data['slot'] == 4) & (data['isdefault'] == 1)]['dz_rms'][0]
     assert np.allclose(dz_rms, 0.047886185719034906)
 
-
+@pytest.mark.skipif('not HAS_VV_ARCHIVE', reason='Test requires vv archive')
 def test_get_vv():
     obs = vv.get_vv(16504)
     assert np.allclose(obs['slots']['7']['dz_rms'], 0.11610256063309182)
 
-
+@pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 def test_run_vv():
     obi = process.get_arch_vv(2121)
     assert np.allclose(obi.info()['sim']['max_d_dy'], 0.002197265625)
 
+@pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 def test_run_vv_omitted_slot():
     # This test run on obsid with omitted slot is just testing for unhandled exceptions
     process.get_arch_vv(19991, version='last')
 
+@pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 def test_run_vv_multi_interval():
     # This test run on obsid with multiple intervals is just testing for unhandled exceptions
     process.get_arch_vv(18980, version='last')
 
+@pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 def test_run_vv_omitted_fid():
     process.get_arch_vv(18978, version='last')
 
+@pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 def test_run_vv_7_track_slots():
     # Run on an obsid with only 7 slots *commanded* during Kalman
     process.get_arch_vv(19847, version='last')


### PR DESCRIPTION
A first pass at just skipping tests if components of the mica archive are not available to do those tests.

This is ugly due to overconfiguration of the paths.  Will clean that up in future PRs.

I haven't found a good way to skip all of the remaining tests in a file if a condition is met, so just copied the decorators down these files.