### PR TITLE
Fix open file leak in reading  dark cals

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -123,7 +123,7 @@ def _get_dark_cal_image_props(date, select='before', t_ccd_ref=None, aca_image=F
     """
     DARK_CAL['id'] = get_dark_cal_id(date, select)
 
-    hdus = fits.open(MICA_FILES['dark_image.fits'].abs)
+    hdus = fits.open(MICA_FILES['dark_image.fits'].abs, memmap=False)
     dark = hdus[0].data
     hdus.close()
 


### PR DESCRIPTION
This fixes a critical bug in `_get_dark_cal_image_props` where the `fits.open()` call uses the default `memmap=True` and thus leaves the file handle open despite the `hdus.close()` call.  It was discovered in proseco testing where running a few hundred obsids reached the Python limit for open files.

Can we get this and my previous 4 pull requests into a new release?  This is the only critical one, of course.