### PR TITLE
Clip negative dark map values by default

### DIFF
--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -11,9 +11,11 @@ from chandra_aca.aca_image import ACAImage
 
 HAS_DARK_ARCHIVE = os.path.exists(dark_cal.MICA_FILES['dark_cals_dir'].abs)
 
+
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_date_to_dark_id():
     assert dark_cal.date_to_dark_id('2011-01-15T12:00:00') == '2011015'
+
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_dark_id_to_date():
@@ -27,16 +29,20 @@ def test_dark_temp_scale():
     scale = dark_cal.dark_temp_scale(-10., -14, scale_4c=2.0)
     assert scale == 0.5  # Should be an exact match
 
+
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_get_dark_cal_id():
     assert dark_cal.get_dark_cal_id('2007:008', 'nearest') == '2007006'
     assert dark_cal.get_dark_cal_id('2007:008', 'before') == '2007006'
     assert dark_cal.get_dark_cal_id('2007:008', 'after') == '2007069'
 
+
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
+@pytest.mark.parametrize('allow_negative', [True, False])
 @pytest.mark.parametrize('aca_image', [True, False])
-def test_get_dark_cal_image(aca_image):
-    image = dark_cal.get_dark_cal_image('2007:008', aca_image=aca_image)
+def test_get_dark_cal_image(aca_image, allow_negative):
+    image = dark_cal.get_dark_cal_image('2007:008', aca_image=aca_image,
+                                        allow_negative=allow_negative)
     assert image.shape == (1024, 1024)
     if aca_image:
         assert image.row0 == -512
@@ -46,18 +52,27 @@ def test_get_dark_cal_image(aca_image):
     else:
         assert type(image) is np.ndarray
 
+    # Raw dark cal images always have negative values unless clipped
+    assert np.any(image < 0) == allow_negative
+
+
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
+@pytest.mark.parametrize('allow_negative', [True, False])
 @pytest.mark.parametrize('aca_image', [True, False])
-def test_get_dark_cal_props(aca_image):
+def test_get_dark_cal_props(aca_image, allow_negative):
     props = dark_cal.get_dark_cal_props('2007:008')
     assert len(props['replicas']) == 5
     assert props['start'] == '2007:006:01:56:46.817'
 
-    props = dark_cal.get_dark_cal_props('2007:008', include_image=True, aca_image=aca_image)
+    props = dark_cal.get_dark_cal_props('2007:008', include_image=True,
+                                        aca_image=aca_image,
+                                        allow_negative=allow_negative)
     assert len(props['replicas']) == 5
     assert props['start'] == '2007:006:01:56:46.817'
     assert props['image'].shape == (1024, 1024)
+    assert np.any(props['image'] < 0) == allow_negative
     assert type(props['image']) is (ACAImage if aca_image else np.ndarray)
+
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_get_dark_cal_props_table():


### PR DESCRIPTION
Slightly controversial, but this makes the default in mica to clip negative values from dark maps returned by `dark_cal` functions.  

Since those values are not physical, I can't think of a good reason to not do this clipping globally by default.  Looking at SOT uses of [get_dark_cal_image](https://github.com/search?p=2&q=org%3Asot+get_dark_cal_image&type=Code) and [get_dark_cal_props](https://github.com/search?q=org%3Asot+get_dark_cal_props&type=Code) doesn't show anything that would break from not having negative pixel values (from what I saw).

There are doubtless non-versioned scripts or notebooks that show dark current distributions that would now be clipped and might require update.