### PR TITLE
Remove SKA_FILES context dict (unused after acdc transition)

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -21,11 +21,8 @@ from . import file_defs
 
 DARK_CAL = pyyaks.context.ContextDict('dark_cal')
 
-SKA_FILES = pyyaks.context.ContextDict('ska_files', basedir='/proj/sot/ska')
-SKA_FILES.update(file_defs.SKA_FILES)
-
 MICA_FILES = pyyaks.context.ContextDict('update_mica_files',
-                                        basedir=os.path.join(MICA_ARCHIVE_PATH))
+                                        basedir=MICA_ARCHIVE_PATH)
 MICA_FILES.update(file_defs.MICA_FILES)
 
 

--- a/mica/archive/aca_dark/file_defs.py
+++ b/mica/archive/aca_dark/file_defs.py
@@ -2,11 +2,6 @@
 """
 Files for ACA dark current access and processing
 """
-SKA_FILES = {'dark_cals_dir': 'data/aca_dark_cal',
-             'dark_cal_dir': 'data/aca_dark_cal/{{dark_cal.id}}',
-             'dark_image': 'data/aca_dark_cal/{{dark_cal.id}}/imd',
-             'dark_info': 'data/aca_dark_cal/{{dark_cal.id}}/info'}
-
 MICA_FILES = {'dark_cals_dir': 'aca_dark',
               'dark_cal_dir': 'aca_dark/{{dark_cal.id}}',
               'dark_image': 'aca_dark/{{dark_cal.id}}/image',


### PR DESCRIPTION
I searched for SKA_FILES in sot org code and found no other matches.

This also removes an unnecessary `os.path.join`.