### PR TITLE
Small fix for PCAD table generation + SCM version changes

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/mica/__init__.py
+++ b/mica/__init__.py
@@ -1,5 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-__version__ = '4.19'
+
+import ska_helpers
+
+__version__ = ska_helpers.get_version(__package__)
 
 
 def test(*args, **kwargs):

--- a/mica/web/pcad_table.py
+++ b/mica/web/pcad_table.py
@@ -1,5 +1,11 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from kadi import events
+
+import kadi.events.query as events
+# This import style (instead of "from kadi import events") is required due to a
+# conflict with how the django app is initialized and standalone usage since
+# django 2+. Basically `events/__init__.py` in a django app does not get the
+# auto-generated query references because DJANGO_SETTINGS_MODULE is set.
+
 import numpy as np
 from Chandra.Time import DateTime
 from Ska.engarchive import fetch

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,6 @@ import os
 from setuptools import setup
 from pathlib import Path
 
-from mica import __version__
-
 try:
     from testr.setup_helper import cmdclass
 except ImportError:
@@ -32,7 +30,8 @@ else:
 
 setup(name='mica',
       description='Mica aspects archive',
-      version=__version__,
+      use_scm_version=True,
+      setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       author='Jean Connelly',
       author_email='jconnelly@cfa.harvard.edu',
       license=license,


### PR DESCRIPTION
This is based off the `scm_version` branch #211 (needed for testing), and includes a little fix in order to work with the kadi `py3-server` branch.

