### PR TITLE
Remove dark model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 doc/_build
 *.pyc
 *~
-
+*.egg-info

--- a/doc/aca_dark_current.rst
+++ b/doc/aca_dark_current.rst
@@ -60,13 +60,6 @@ for the invidivual dark replicas (typically 5).  These in turn use ACA hdr3 diag
 telemetry for high-resolution temperature readouts which are available before and after
 (but not during) each replica.
 
-Dark current modeling
-^^^^^^^^^^^^^^^^^^^^^^^
-
-This module will contain functions related to analytical models of the dark current
-as well as derived predictions of ACA guide and acquisition performance based on
-correlations with the warm pixel fraction.  This is still in work, see :ref:`api_dark_model`.
-
 Processing
 ^^^^^^^^^^^^^^
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -13,14 +13,6 @@
 .. automodule:: mica.archive.aca_dark.dark_cal
     :members:
 
-.. _api_dark_model:
-
-:mod:`mica.archive.aca_dark.dark_model`
-----------------------------------------
-
-.. automodule:: mica.archive.aca_dark.dark_model
-    :members:
-
 :mod:`mica.archive.aca_hdr3`
 ============================
 

--- a/mica/archive/aca_dark/__init__.py
+++ b/mica/archive/aca_dark/__init__.py
@@ -1,3 +1,2 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from .dark_cal import *
-from .dark_model import *
+from .dark_cal import *  # noqa

--- a/mica/archive/aca_dark/dark_model.py
+++ b/mica/archive/aca_dark/dark_model.py
@@ -1,4 +1,0 @@
-# Licensed under a 3-clause BSD style license - see LICENSE.rst
-import warnings
-warnings.warn("mica.archive.aca_dark.dark_model is deprecated.  See chandra_aca.dark_model", DeprecationWarning)
-from chandra_aca.dark_model import *


### PR DESCRIPTION
## Description

Remove the `dark_model` module which has been deprecated for a while.  There are no instances of dark_model coming from mica in the `sot` org.

This is causing warnings now in pytest every time `mica.archive.aca_dark` gets imported.

## API impact

Any code now importing dark modeling functions from `mica.archive.aca_dark` will now break.

## Testing

- [x] Passes unit tests on MacOS(with a fair number of skips)
