### PR TITLE
Mag stats

### DIFF
--- a/mica/stats/tests/test_guide_stats.py
+++ b/mica/stats/tests/test_guide_stats.py
@@ -7,7 +7,7 @@ import pytest
 from .. import guide_stats
 from .. import update_guide_stats
 
-HAS_GS_TABLE = os.path.exists(update_guide_stats.TABLE_FILE)
+HAS_GS_TABLE = os.path.exists(guide_stats.TABLE_FILE)
 
 
 @pytest.mark.skipif('not HAS_GS_TABLE', reason='Test requires guide stats table')

--- a/mica/stats/tests/test_guide_stats.py
+++ b/mica/stats/tests/test_guide_stats.py
@@ -44,9 +44,8 @@ def test_make_gui_stats():
     # make a new table if the supplied file doesn't exist
     fh, fn = tempfile.mkstemp(suffix='.h5')
     os.unlink(fn)
-    update_guide_stats.TABLE_FILE = fn
     obsid = 20001
     obsid_info, gui, star_info, catalog, temp = update_guide_stats.calc_stats(obsid)
     t = update_guide_stats.table_gui_stats(obsid_info, gui, star_info, catalog, temp)
-    update_guide_stats._save_gui_stats(t)
+    update_guide_stats._save_gui_stats(t, table_file=fn)
     os.unlink(fn)

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -112,7 +112,7 @@ GUIDE_COLS = {
         ('var', 'int'),
         ('pos_err', 'int'),
         ('mag_aca', 'float'),
-        ('mag_err', 'int'),
+        ('mag_aca_err', 'int'),
         ('mag_band', 'int'),
         ('pos_catid', 'int'),
         ('aspq1', 'int'),

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -336,8 +336,8 @@ def calc_gui_stats(data, star_info):
         stats['aoaczan_mean'] = np.mean(kal['AOACZAN{}'.format(slot)])
 
         for dist in ['0.3', '1', '3', '5']:
-            stats['f_within_{}'.format(dist)] = np.count_nonzero(dr < float(dist)) / stats['n_kalman']
-        stats['f_outside_5'] = np.count_nonzero(dr > 5) / stats['n_kalman']
+            stats['f_within_{}'.format(dist)] = np.count_nonzero(dr < float(dist)) / len(kal)
+        stats['f_outside_5'] = np.count_nonzero(dr > 5) / len(kal)
 
         gui_stats[slot] = stats
 

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -451,7 +451,14 @@ def table_gui_stats(obsid_info, gui_stats, star_info, catalog, temp):
     logger.info("arranging stats into tabular data")
     cols = (GUIDE_COLS['obs'] + GUIDE_COLS['cat'] + GUIDE_COLS['stat']
             + GUIDE_COLS['agasc'] + GUIDE_COLS['temp'] + GUIDE_COLS['bad'])
+
+    # Initialize all values to zero
     table = Table(np.zeros((1, 8), dtype=cols).flatten())
+    # Set all columns with mag info to 99.0 initial value instead of zero
+    for col in table.dtype.names:
+        if 'mag' in col:
+            table[col] = 99.0
+
     for col in np.dtype(GUIDE_COLS['obs']).names:
         if col in obsid_info:
             table[col][:] = obsid_info[col]

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -33,7 +33,7 @@ logger.setLevel(logging.INFO)
 if not len(logger.handlers):
     logger.addHandler(logging.StreamHandler())
 
-STAT_VERSION = 0.5
+STAT_VERSION = 0.6
 
 GUIDE_COLS = {
     'obs': [


### PR DESCRIPTION
## Description

Add 5, 16, 50, 84, 95 mag stats to the guide stats table.  This also adds some changes to support running on time ranges to make it easier to do trivial multiprocessing.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

Fixes #216 