### PR TITLE
Recast dark cal image to native byte order

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -122,9 +122,11 @@ def _get_dark_cal_image_props(date, select='before', t_ccd_ref=None, aca_image=F
     """
     DARK_CAL['id'] = get_dark_cal_id(date, select)
 
-    hdus = fits.open(MICA_FILES['dark_image.fits'].abs, memmap=False)
-    dark = hdus[0].data
-    hdus.close()
+    with fits.open(MICA_FILES['dark_image.fits'].abs, memmap=False) as hdus:
+        dark = hdus[0].data
+        # Recast as native byte ordering since FITS is typically not. This
+        # statement is normally the same as dark.astype(np.float32).
+        dark = dark.astype(dark.dtype.type)
 
     with open(MICA_FILES['dark_props.json'].abs, 'r') as fh:
         props = json.load(fh)


### PR DESCRIPTION
## Description

This implements the right upstream fix for https://github.com/sot/chandra_aca/issues/97.

## Testing

- [x] Passes unit tests on MacOS (both mica and chandra_aca using this version of mica)
- [x] Functional testing:
```
In [1]: from mica.archive import aca_dark
In [2]: ccd_bgd = aca_dark.dark_cal.get_dark_cal_image('2019:001', aca_image=True)
In [3]: ccd_bgd.flicker_update(1)
In [4]:  # No failure
```

Fixes https://github.com/sot/chandra_aca/issues/97
