### PR TITLE
Change sybase skip test to check for more restrictive vv creds

### DIFF
--- a/mica/report/tests/test_write_report.py
+++ b/mica/report/tests/test_write_report.py
@@ -8,7 +8,7 @@ from .. import report
 
 try:
     import Ska.DBI
-    with Ska.DBI.DBI(server='sqlsao', dbi='sybase', user='aca_ops', database='axafocat') as db:
+    with Ska.DBI.DBI(server='sqlsao', dbi='sybase', user='jeanconn', database='axafvv') as db:
         HAS_SYBASE_ACCESS = True
 except:
     HAS_SYBASE_ACCESS = False
@@ -17,7 +17,7 @@ except:
 HAS_SC_ARCHIVE = os.path.exists(report.starcheck.FILES['data_root'])
 
 
-@pytest.mark.skipif('not HAS_SYBASE_ACCESS', reason='Report test requires Sybase/OCAT access')
+@pytest.mark.skipif('not HAS_SYBASE_ACCESS', reason='Report test requires Sybase VV access')
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Report test requires mica starcheck archive')
 def test_write_reports():
     """


### PR DESCRIPTION
Change sybase skip test to check for more restrictive vv creds

This should let the report-writing test that uses the axafvv query
run as jeanconn user, but skip for other users.

## Description


## Testing

- [x] Passes unit tests on linux
- [x] Functional testing (the functional testing was the unit testing.  I ran as jeanconn, aca, and kadi users from master and from this branch and see expected test skips).

Fixes #