### PR TITLE
test_get_l0_images ends up trying to load mica/archive/asp1/archfiles…

### DIFF
--- a/mica/archive/tests/test_aca_l0.py
+++ b/mica/archive/tests/test_aca_l0.py
@@ -27,9 +27,9 @@ def test_l0_images_meta():
                             'TIME': np.float64(467055637.49031752)}
 
 has_l0_2007_archive = os.path.exists(os.path.join(aca_l0.CONFIG['data_root'], '2007'))
+has_asp_l1 = os.path.exists(os.path.join(asp_l1.CONFIG['data_root']))
 
-
-@pytest.mark.skipif('not has_l0_2007_archive', reason='Test requires 2007 L0 archive')
+@pytest.mark.skipif('not has_l0_2007_archive or not has_asp_l1', reason='Test requires 2007 L0 archive')
 def test_get_l0_images():
     """
     Do a validation test of get_l0_images:


### PR DESCRIPTION


## Description

When I run locally, test_get_l0_images ends up trying to load mica/archive/asp1/archfiles.db3, so the test fails. Shouldn't it be skipped?

Also, I just copied the same check that is made in test_asp_l1, but this test fails if there are broken links.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [N/A] Functional testing
