### PR TITLE
Remove tables3_api imports

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -19,7 +19,6 @@ from astropy.table import Table
 from astropy.time import Time
 import astropy.units as u
 
-import tables3_api
 from Ska.Shell import bash
 import agasc
 import Ska.DBI

--- a/mica/stats/acq_stats.py
+++ b/mica/stats/acq_stats.py
@@ -1,6 +1,5 @@
 import os
 import tables
-import tables3_api
 
 SKA = os.environ.get('SKA', '/proj/sot/ska')
 TABLE_FILE = os.path.join(SKA, 'data', 'acq_stats', 'acq_stats.h5')

--- a/mica/stats/guide_stats.py
+++ b/mica/stats/guide_stats.py
@@ -1,6 +1,5 @@
 import os
 import tables
-import tables3_api
 
 SKA = os.environ.get('SKA', '/proj/sot/ska')
 TABLE_FILE = os.path.join(SKA, 'data', 'guide_stats', 'guide_stats.h5')

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -10,7 +10,6 @@ from Chandra.Time import DateTime
 import mica.archive.obspar
 from mica.starcheck import get_starcheck_catalog, get_starcheck_catalog_at_date
 import tables
-import tables3_api
 import numpy as np
 import Ska.quatutil
 import Ska.astro


### PR DESCRIPTION
## Description

Remove tables3_api imports.  Since we're no longer building tables3_api for shiny and it really isn't needed anymore (we're not doing Py2 backports) it is fine to just cut it here.


## Testing

I think the unit testing is sufficient.

- [x] Passes unit tests on linux
- [ ] Functional testing 

Fixes #