### PR TITLE
Updates for passing tests on shiny

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -226,7 +226,7 @@ def get_dark_cal_props_table(start=None, stop=None, include_image=False, as_tabl
 
     :returns: astropy Table or list of dark calibration properties
     """
-    start_id = date_to_dark_id('1999:001' if start is None else start)
+    start_id = date_to_dark_id('1999:001:12:00:00' if start is None else start)
     stop_id = date_to_dark_id(stop)
     dark_dirs = [dark_id for dark_id in get_dark_cal_dirs()
                  if dark_id >= start_id and dark_id <= stop_id]

--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -72,7 +72,7 @@ def make_data_table(lines):
     return files
 
 
-def make_table_from_scratch(table_file, cda_fetch_url, start='2015:001'):
+def make_table_from_scratch(table_file, cda_fetch_url, start='2015:001:12:00:00'):
     logger.info("Fetching new CDA list from %s" % start)
     ct_start = DateTime(start)
     query = ("?tstart={:02d}-{:02d}-{:04d}&pattern=acaimgc%%25&submit=Search".format(

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -32,16 +32,16 @@ def test_dark_temp_scale():
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_get_dark_cal_id():
-    assert dark_cal.get_dark_cal_id('2007:008', 'nearest') == '2007006'
-    assert dark_cal.get_dark_cal_id('2007:008', 'before') == '2007006'
-    assert dark_cal.get_dark_cal_id('2007:008', 'after') == '2007069'
+    assert dark_cal.get_dark_cal_id('2007:008:12:00:00', 'nearest') == '2007006'
+    assert dark_cal.get_dark_cal_id('2007:008:12:00:00', 'before') == '2007006'
+    assert dark_cal.get_dark_cal_id('2007:008:12:00:00', 'after') == '2007069'
 
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 @pytest.mark.parametrize('allow_negative', [True, False])
 @pytest.mark.parametrize('aca_image', [True, False])
 def test_get_dark_cal_image(aca_image, allow_negative):
-    image = dark_cal.get_dark_cal_image('2007:008', aca_image=aca_image,
+    image = dark_cal.get_dark_cal_image('2007:008:12:00:00', aca_image=aca_image,
                                         allow_negative=allow_negative)
     assert image.shape == (1024, 1024)
     if aca_image:
@@ -60,11 +60,11 @@ def test_get_dark_cal_image(aca_image, allow_negative):
 @pytest.mark.parametrize('allow_negative', [True, False])
 @pytest.mark.parametrize('aca_image', [True, False])
 def test_get_dark_cal_props(aca_image, allow_negative):
-    props = dark_cal.get_dark_cal_props('2007:008')
+    props = dark_cal.get_dark_cal_props('2007:008:12:00:00')
     assert len(props['replicas']) == 5
     assert props['start'] == '2007:006:01:56:46.817'
 
-    props = dark_cal.get_dark_cal_props('2007:008', include_image=True,
+    props = dark_cal.get_dark_cal_props('2007:008:12:00:00', include_image=True,
                                         aca_image=aca_image,
                                         allow_negative=allow_negative)
     assert len(props['replicas']) == 5
@@ -76,7 +76,7 @@ def test_get_dark_cal_props(aca_image, allow_negative):
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_get_dark_cal_props_table():
-    props = dark_cal.get_dark_cal_props_table('2007:001', '2008:001')
+    props = dark_cal.get_dark_cal_props_table('2007:001:12:00:00', '2008:001:12:00:00')
     assert np.allclose(props['eb'], [24.6, 25.89, 51.13, 1.9])
     assert props.colnames == ['ccd_temp', 'date', 'dec', 'dur', 'eb', 'el', 'id', 'l_l0',
                               'ra', 'start', 'stop', 'sun_el', 'zodib']
@@ -86,7 +86,7 @@ def test_get_dark_cal_props_table():
 def test_get_dark_cal_props_table_acdc():
     """Just acdc dark cals, giving a non-masked result
     """
-    props = dark_cal.get_dark_cal_props_table('2019:150', '2019:160')
+    props = dark_cal.get_dark_cal_props_table('2019:150:12:00:00', '2019:160:12:00:00')
     assert not hasattr(props['t_ccd'], 'mask')
     assert props.colnames == ['date', 't_ccd', 'n_ccd_img', 'ccd_temp', 'datestart',
                               'datestop', 'filename']
@@ -96,7 +96,7 @@ def test_get_dark_cal_props_table_acdc():
 def test_get_dark_cal_props_table_mixed():
     """Mix of "classic" dark cals and acdc dark cals, giving a masked table
     """
-    props = dark_cal.get_dark_cal_props_table('2019:001', '2019:160')
+    props = dark_cal.get_dark_cal_props_table('2019:001:12:00:00', '2019:160:12:00:00')
     assert np.allclose(props['eb'], [1.82, -49.53, -100])
     assert np.all(props['eb'].mask == [False, False, True])
     assert np.allclose(props['t_ccd'], [-100, -100, -11.086])

--- a/mica/archive/tests/test_aca_hdr3.py
+++ b/mica/archive/tests/test_aca_hdr3.py
@@ -21,7 +21,7 @@ def test_MSIDset():
     msids = sorted(msids)
 
     # Read all MSIDs as a set
-    dat = aca_hdr3.MSIDset(msids, '2010:001', '2010:003')
+    dat = aca_hdr3.MSIDset(msids, '2010:001:12:00:00', '2010:003:12:00:00')
 
     val_lengths = np.array([len(dat[msid].vals) for msid in msids])
     time_lengths = np.array([len(dat[msid].times) for msid in msids])

--- a/mica/archive/tests/test_obspar.py
+++ b/mica/archive/tests/test_obspar.py
@@ -10,8 +10,8 @@ def test_get_obsids():
     """
     Test that archive.obspar.get_obsids gets a reasonable set of obsids.
     """
-    start = "2016:001"
-    stop = "2016:005"
+    start = "2016:001:12:00:00"
+    stop = "2016:005:12:00:00"
     mica_obs = obspar.get_obsids(start, stop)
     # from kadi.events.obsids.filter(start, stop)
     kadi_obsid_list = [51365, 18736, 18036, 18203, 18119,

--- a/mica/starcheck/starcheck.py
+++ b/mica/starcheck/starcheck.py
@@ -90,7 +90,7 @@ def get_monitor_windows(start=None, stop=None, min_obsid=40000, config=None):
     """
     if config is None:
         config = DEFAULT_CONFIG
-    start_date = DateTime(start or '1999:001').date
+    start_date = DateTime(start or '1999:001:12:00:00').date
     stop_date = DateTime(stop).date
     with Ska.DBI.DBI(**config['starcheck_db']) as db:
         mons = db.fetchall("""select obsid, mp_starcat_time as mp_starcat_date, type, sz, yang, zang, dir

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -73,8 +73,8 @@ def get_trak_cat_from_telem(start, stop, cmd_quat):
 
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_validate_catalogs_over_range():
-    start = '2017:001'
-    stop = '2017:002'
+    start = '2017:001:12:00:00'
+    stop = '2017:002:12:00:00'
     dwells = events.dwells.filter(start, stop)
     for dwell in dwells:
         print(dwell)
@@ -142,7 +142,7 @@ def test_obsid_catalog_fetch():
 
 @pytest.mark.skipif('not HAS_SC_ARCHIVE', reason='Test requires starcheck archive')
 def test_monitor_fetch():
-    mons = starcheck.get_monitor_windows(start='2009:002', stop='2009:007')
+    mons = starcheck.get_monitor_windows(start='2009:002:12:00:00', stop='2009:007:12:00:00')
     assert len(mons) == 10
 
 

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -410,7 +410,7 @@ def calc_acq_stats(manvr, vals, times):
 
 def _get_obsids_to_update(check_missing=False):
     if check_missing:
-        last_tstart = '2007:271'
+        last_tstart = '2007:271:12:00:00'
         kadi_obsids = events.obsids.filter(start=last_tstart)
         try:
             h5 = tables.open_file(table_file, 'r')
@@ -427,7 +427,7 @@ def _get_obsids_to_update(check_missing=False):
             last_tstart = tbl.cols.guide_tstart[tbl.colindexes['guide_tstart'][-1]]
             h5.close()
         except:
-            last_tstart = '2002:012'
+            last_tstart = '2002:012:12:00:00'
         kadi_obsids = events.obsids.filter(start=last_tstart)
         # Skip the first obsid (as we already have it in the table)
         obsids = [o.obsid for o in kadi_obsids][1:]

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -346,7 +346,7 @@ def calc_gui_stats(data, star_info):
 
 def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop=None):
     if check_missing:
-        last_tstart = start if start is not None else '2007:271'
+        last_tstart = start if start is not None else '2007:271:12:00:00'
         kadi_obsids = events.obsids.filter(start=last_tstart)
         try:
             h5 = tables.open_file(table_file, 'r')
@@ -363,7 +363,7 @@ def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop
             last_tstart = tbl.cols.kalman_tstart[tbl.colindexes['kalman_tstart'][-1]]
             h5.close()
         except:
-            last_tstart = start if start is not None else  '2002:012'
+            last_tstart = start if start is not None else  '2002:012:12:00:00'
         kadi_obsids = events.obsids.filter(start=last_tstart, stop=stop)
         # Skip the first obsid (as we already have it in the table)
         obsids = [o.obsid for o in kadi_obsids][1:]

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
+


### PR DESCRIPTION
## Description

Updates for passing tests on shiny and remove import of `tables3_api`.

## Testing

- [x] Passes unit tests on MacOS (shiny) *but most tests skipped*
- [x] Passes unit tests on MacOS (flight) *but most tests skipped*
- [x] Passes unit tests on linux (flight)
- [N/A] Functional testing

I have not confirmed passing tests on shiny / linux since that doesn't yet exist.