### PR TITLE
Remove use of Chandra.cmd_states

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -25,7 +25,7 @@ import Ska.DBI
 from Chandra.Time import DateTime
 from Ska.engarchive import fetch_sci
 from kadi import events
-from Chandra.cmd_states import fetch_states
+from kadi.commands.states import get_states
 import mica
 from mica.archive import obspar
 from mica.catalog import catalog
@@ -847,8 +847,8 @@ def save_state_in_db(obsid, notes):
 
 
 def update():
-    recent_obs = np.unique(fetch_states(start=DateTime(-7), vals=['obsid'])['obsid'])
-    for obs in recent_obs:
+    recent_obs = get_states(start=-7, state_keys=['obsid'], merge_identical=True)
+    for obs in recent_obs['obsid']:
         process_obsids([int(obs)]) # the int() is here to keep json happy downstream
 
 

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -231,7 +231,7 @@ def target_summary(obsid):
 def guess_shortterm(mp_dir):
 #file:///proj/web-icxc/htdocs/mp/schedules/cycle14/JUL2213B.html
     mp_short_top = '/proj/web-icxc/htdocs/mp/schedules'
-    dir_match = re.match('/\d{4}/(\w{3}\d{4})/ofls(\w)', mp_dir)
+    dir_match = re.match(r'/\d{4}/(\w{3}\d{4})/ofls(\w)', mp_dir)
     if not dir_match:
         return None
     dir_string = "{}{}.html".format(
@@ -245,7 +245,7 @@ def guess_shortterm(mp_dir):
 
 
 def guess_fot_summary(mp_dir):
-    dir_match = re.match('/(\d{4})/((\w{3})\d{4})/ofls(\w)', mp_dir)
+    dir_match = re.match(r'/(\d{4})/((\w{3})\d{4})/ofls(\w)', mp_dir)
     if not dir_match:
         return None
     appr_loads = 'http://occweb.cfa.harvard.edu/occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS'
@@ -333,10 +333,10 @@ def obs_links(obsid, sequence=None, plan=None):
                             'label': 'Centroid Dashboard'}
 
     if mp_dir is not None:
-        dir_match = re.match('/\d{4}/(\w{3}\d{4})/ofls(\w)', mp_dir)
+        dir_match = re.match(r'/\d{4}/(\w{3}\d{4})/ofls(\w)', mp_dir)
         mp_label = "{}{}".format(dir_match.group(1),
                                  dir_match.group(2).upper())
-        mp_date_m = re.match('(\d{4}):(\d{3}):\d{2}:\d{2}:\d{2}\.\d{3}', mp_date)
+        mp_date_m = re.match(r'(\d{4}):(\d{3}):\d{2}:\d{2}:\d{2}\.\d{3}', mp_date)
         if mp_date_m:
             year = int(mp_date_m.group(1))
             doy = int(mp_date_m.group(2))
@@ -588,7 +588,7 @@ def main(obsid):
         return
 
     if not er and 'shortterm' in links:
-        dir_match = re.match('/\d{4}/(\w{3}\d{4})/ofls(\w)', mp_dir)
+        dir_match = re.match(r'/\d{4}/(\w{3}\d{4})/ofls(\w)', mp_dir)
         mp_label = "{}{}".format(dir_match.group(1),
                                  dir_match.group(2).upper())
         last_sched = 'in <A HREF="{}">{}</A> at {}'.format(

--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -7,11 +7,8 @@ from itertools import count
 from operator import itemgetter
 from pathlib import Path
 
-import numpy as np
-
 from six.moves import zip
 from Chandra.Time import DateTime
-from Chandra.cmd_states import get_cmd_states
 import Ska.Shell
 import Ska.DBI
 

--- a/mica/starcheck/starcheck.py
+++ b/mica/starcheck/starcheck.py
@@ -1,10 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 import re
-import numpy as np
 
 from Chandra.Time import DateTime
-from Chandra.cmd_states import get_cmd_states
+from kadi.commands.states import get_states
 import Ska.DBI
 from kadi import events
 from astropy.table import Table
@@ -197,7 +196,8 @@ def get_starcheck_catalog_at_date(date, starcheck_db=None, timelines_db=None):
     # There is a tiny window of time in cmd_states but not yet in kadi, but this code tries to
     # grab the dwell and maneuver that would be related to a date in that range
     if date < last_tl and len(dwells) == 0:
-        pcad_states = get_cmd_states.fetch_states(start=DateTime(date) - 2, vals=['pcad_mode'])
+        pcad_states = get_states(start=DateTime(date) - 2, state_keys=['pcad_mode'],
+                                 merge_identical=True)
         dwell = pcad_states[(pcad_states['pcad_mode'] == 'NPNT') & (pcad_states['datestop'] >= date)][0]
         manvr = pcad_states[(pcad_states['pcad_mode'] == 'NMAN')
                             & (pcad_states['datestop'] <= dwell['datestart'])][-1]


### PR DESCRIPTION
## Description

This updates mica to use kadi.commands.states.get_states() instead of Chandra.cmd_states.

## Testing

- [x] Passes unit tests on MacOS (shiny, many tests skipped)
- [x] Passes unit tests on linux (flight)
- [?] Functional testing

Not clear how to test the changes in `report.py`.