### PR TITLE
More shiny fixes

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -259,7 +259,8 @@ def guess_fot_summary(mp_dir):
 
 
 def official_vv(obsid):
-    vv_db = Ska.DBI.DBI(dbi='sybase', server='sqlsao', user='jeanconn', database='axafvv')
+    user = os.environ.get('USER') or os.environ.get('LOGNAME')
+    vv_db = Ska.DBI.DBI(dbi='sybase', server='sqlsao', user=user, database='axafvv')
     vv = vv_db.fetchone("""select vvid from vvreport where obsid = {obsid}
                            and creation_date = (
                               select max(creation_date) from vvreport where obsid = {obsid})
@@ -275,7 +276,8 @@ def official_vv(obsid):
 
 
 def official_vv_notes(obsid, summary):
-    vv_db = Ska.DBI.DBI(dbi='sybase', server='sqlsao', user='jeanconn', database='axafvv',
+    user = os.environ.get('USER') or os.environ.get('LOGNAME')
+    vv_db = Ska.DBI.DBI(dbi='sybase', server='sqlsao', user=user, database='axafvv',
                         numpy=False)
     all_vv = vv_db.fetchall("""select * from vvreport where obsid = {obsid}
                         """.format(obsid=obsid))

--- a/mica/report/tests/test_write_report.py
+++ b/mica/report/tests/test_write_report.py
@@ -3,14 +3,22 @@ import tempfile
 import os
 import shutil
 import pytest
+from warnings import warn
+
+from testr.test_helper import on_head_network, has_sybase
 
 from .. import report
 
 try:
     import Ska.DBI
-    with Ska.DBI.DBI(server='sqlsao', dbi='sybase', user='jeanconn', database='axafvv') as db:
+    user = os.environ.get('USER') or os.environ.get('LOGNAME')
+    with Ska.DBI.DBI(server='sqlsao', dbi='sybase', user=user, database='axafvv') as db:
         HAS_SYBASE_ACCESS = True
-except:
+except Exception:
+    if on_head_network() and not has_sybase():
+        warn("On HEAD but no sybase access. Run ska_envs or define SYBASE/SYBASE_OCS")
+    if on_head_network() and has_sybase():
+        warn(f"{user} account probably doesn't have axafvv database access")
     HAS_SYBASE_ACCESS = False
 
 

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -1024,7 +1024,7 @@ class AspectInterval(object):
                 mock_prop = dict(
                                  id_status='OMITTED',
                                  slot=slot,
-                                 id_string=ocat_info['id'],
+                                 id_string=str(ocat_info['id']),
                                  id_num=ocat_info['id'],
                                  ang_y_nom=ocat_info['y_ang'],
                                  ang_z_nom=ocat_info['z_ang'],


### PR DESCRIPTION
## Description

Fix V&V handling of missing fid in shiny (also works in ska3-flight). 
Also set code to assume USER to run the axafvv queries so the V&V report making can work as user other than 'jeanconn'.
Set report writing test to work as USER as well and provide new warnings on Linux if the axafvv database access doesn't work.

## Testing

- [x] Passes unit tests on Linux with ska3-flight or shiny 
- [x] Functional testing does not apply as the code changes were to remove warnings and errors in unit tests outputs

Fixes #228, #179, #152 