### PR TITLE
Use vectorized Quat

### DIFF
--- a/mica/archive/asp_l1.py
+++ b/mica/archive/asp_l1.py
@@ -13,7 +13,7 @@ import os
 import logging
 import numpy as np
 from astropy.table import Table
-from mica.quaternion import Quat
+from Quaternion import Quat
 
 from mica.archive import obsid_archive
 from mica.archive import asp_l1_proc
@@ -215,13 +215,13 @@ def get_atts_from_files(asol_files, acal_files, aqual_files, filter=True):
                        & (asol['time'] <= (aqual['time'][idx] + 1.025)))
                 asol = asol[~nok]
         # Make a Nx4 list of the inv misalign quats
-        q_mis_inv = np.repeat(Quat(acal['aca_misalign'][0]).inv().q,
+        q_mis_inv = np.repeat(Quat(transform=acal['aca_misalign'][0]).inv().q,
                               len(asol)).reshape((4, len(asol))).transpose()
         # Quaternion multiply the asol quats with that inv misalign and save
         # I could also do this with the transform matrix and then only need
         # one accessory quat function.
         q_att_name = 'q_att_raw' if 'q_att_raw' in asol.colnames else 'q_att'
-        att_chunks.append((Quat(asol[q_att_name]) * Quat(q_mis_inv)).q)
+        att_chunks.append((Quat(q=asol[q_att_name]) * Quat(q=q_mis_inv)).q)
         time_chunks.append(np.array(asol['time']))
         records.append(asol.meta)
     if len(att_chunks) > 0 and len(time_chunks) > 0:

--- a/mica/archive/asp_l1.py
+++ b/mica/archive/asp_l1.py
@@ -214,14 +214,17 @@ def get_atts_from_files(asol_files, acal_files, aqual_files, filter=True):
                 nok = ((asol['time'] >= (aqual['time'][idx] - 1.025))
                        & (asol['time'] <= (aqual['time'][idx] + 1.025)))
                 asol = asol[~nok]
-        # Make a Nx4 list of the inv misalign quats
-        q_mis_inv = np.repeat(Quat(transform=acal['aca_misalign'][0]).inv().q,
-                              len(asol)).reshape((4, len(asol))).transpose()
+
+        # Transpose of transform/rotation matrix is the inverse
+        aca_mis_inv = acal['aca_misalign'][0].transpose()
+
+        # Repeat the transform to match asol
+        aca_mis_inv = np.repeat(aca_mis_inv[np.newaxis, ...], repeats=len(asol), axis=0)
+        q_mis_inv = Quat(transform=aca_mis_inv)
+
         # Quaternion multiply the asol quats with that inv misalign and save
-        # I could also do this with the transform matrix and then only need
-        # one accessory quat function.
         q_att_name = 'q_att_raw' if 'q_att_raw' in asol.colnames else 'q_att'
-        att_chunks.append((Quat(q=asol[q_att_name]) * Quat(q=q_mis_inv)).q)
+        att_chunks.append((Quat(q=asol[q_att_name]) * q_mis_inv).q)
         time_chunks.append(np.array(asol['time']))
         records.append(asol.meta)
     if len(att_chunks) > 0 and len(time_chunks) > 0:

--- a/mica/quaternion.py
+++ b/mica/quaternion.py
@@ -35,6 +35,7 @@ Quaternion provides a class for manipulating quaternion objects.  This class pro
 ## SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import numpy as np
+import warnings
 
 
 class Quat(object):
@@ -101,6 +102,7 @@ class Quat(object):
 
     """
     def __init__(self, attitude, intype=None):
+        warnings.warn("mica.quaternion is deprecated as of Quaternion 3.5.0", FutureWarning)
         self._q = None
         self._equatorial = None
         self._ra0 = None

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -16,10 +16,10 @@ from kadi import events
 from Ska.engarchive import fetch, fetch_sci
 import mica.archive.obspar
 from mica.starcheck.starcheck import get_starcheck_catalog_at_date
-import Ska.quatutil
 import Ska.astro
-from mica.quaternion import Quat
+from Quaternion import Quat
 from chandra_aca import dark_model
+from chandra_aca.transform import radec_to_eci
 
 # Ignore known numexpr.necompiler and table.conditions warning
 warnings.filterwarnings(
@@ -156,10 +156,10 @@ def get_options():
 def _deltas_vs_obc_quat(vals, times, catalog):
     # Misalign is the identity matrix because this is the OBC quaternion
     aca_misalign = np.array([[1, 0, 0], [0, 1, 0], [0, 0, 1]])
-    q_att = Quat(np.array([vals['AOATTQT1'],
-                           vals['AOATTQT2'],
-                           vals['AOATTQT3'],
-                           vals['AOATTQT4']]).transpose())
+    q_att = Quat(q=np.array([vals['AOATTQT1'],
+                             vals['AOATTQT2'],
+                             vals['AOATTQT3'],
+                             vals['AOATTQT4']]).transpose())
     Ts = q_att.transform
     acqs = catalog
 
@@ -186,7 +186,7 @@ def _deltas_vs_obc_quat(vals, times, catalog):
             continue
         ra = star['RA_PMCORR']
         dec = star['DEC_PMCORR']
-        star_pos_eci = Ska.quatutil.radec2eci(ra, dec)
+        star_pos_eci = radec_to_eci(ra, dec)
         d_aca = np.dot(np.dot(aca_misalign, Ts.transpose(0, 2, 1)),
                        star_pos_eci).transpose()
         yag[slot] = np.arctan2(d_aca[:, 1], d_aca[:, 0]) * R2A

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -1179,7 +1179,7 @@ class AspectInterval(object):
                                             )
 
     def _calc_guide_deltas(self):
-        from mica.quaternion import Quat
+        from Quaternion import Quat
         self.deltas = {}
         asol = self.asol
         cen = self.cen
@@ -1200,7 +1200,7 @@ class AspectInterval(object):
             logger.debug('Found %d centroids ' % len(ceni))
             if len(ceni) < 2:
                 continue
-            q_atts = Quat(q_att[ok])
+            q_atts = Quat(q=q_att[ok])
             Ts = q_atts.transform
             # use ang_y or ang_y_sm?
             #inside = np.dot(aca_misalign, Ts.transpose(0,2,1)).transpose(1,0,2)


### PR DESCRIPTION
## Description

Use modern vectorized Quaternion.Quat instead of mica.quaterion

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)

Did not do additional function testing except for spot-checking a few of the intermediate matrices to see if they looked reasonable compared to master.

Fixes #