### PR TITLE
Don't throw error if there is more than one log (more than one aspect interval)

### DIFF
--- a/mica/archive/asp_l1_proc.py
+++ b/mica/archive/asp_l1_proc.py
@@ -57,10 +57,10 @@ def update(obsids, config=None):
             procdir = os.path.dirname(sol)
 
             # As of DS 10.8.3, there are both "com" logs and per-ai logs.
-            # This glob should get the per-ai logs.  We only want one
-            # of them to get an obspar_version.
+            # This glob should get the per-ai logs.  We use the first one
+            # to get an obspar version.
             logfiles = get_globfiles(os.path.join(procdir, "asp_l1_f*log*"),
-                                     minfiles=1, maxfiles=1)
+                                     minfiles=1, maxfiles=None)
             aspect_log = gzip.open(logfiles[0], 'rt').read()
 
             # read the obspar version with a regex from the log


### PR DESCRIPTION
## Description

Don't throw error if there is more than one log (more than one aspect interval)

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] No Functional testing

Fixes #243 