### PR TITLE
removed outdated documentation section

### DIFF
--- a/docs/aca_dark_current.rst
+++ b/docs/aca_dark_current.rst
@@ -59,9 +59,3 @@ Note that the temperature assigned to a dark calibration is the mean of the temp
 for the invidivual dark replicas (typically 5).  These in turn use ACA hdr3 diagnostic
 telemetry for high-resolution temperature readouts which are available before and after
 (but not during) each replica.
-
-Processing
-^^^^^^^^^^^^^^
-
-This module updates the MICA ACA dark current archive when new dark current calibrations
-are completed.  For details see the API documentation at :ref:`api_update_aca_dark`.


### PR DESCRIPTION
## Description

Strictly speaking, this should be replaced by a new section with the right information. I just don't know what that is and want to get rid of the warnings.

## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #