### PR TITLE
L0 ingest issues (both shiny and repro V)

### DIFF
--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -5,6 +5,7 @@ import re
 import logging
 import shutil
 import time
+import gzip
 from astropy.table import Table
 import astropy.io.fits as pyfits
 import numpy as np
@@ -752,7 +753,6 @@ class Updater(object):
             filename = have_files[0]
             # if it isn't gzipped, just gzip it
             if re.match(r'.*\.fits$', filename):
-                import gzip
                 f_in = open(file, 'rb')
                 f_out = gzip.open("%s.gz" % filename, 'wb')
                 f_out.writelines(f_in)

--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -40,7 +40,7 @@ FILETYPE = {'level': 'L0',
             'instrum': 'PCAD',
             'content': 'ACADATA',
             'arc5gl_query': 'ACA0',
-            'fileglob': '*fits.gz'}
+            'fileglob': 'aca*fits*'}
 
 ACA_DTYPE = (('TIME', '>f8'), ('QUALITY', '>i4'), ('MJF', '>i4'),
              ('MNF', '>i4'),
@@ -552,7 +552,7 @@ class Updater(object):
                          and 'fileglob' for arc5gl.  For ACA0:
                          {'level': 'L0', 'instrum': 'PCAD',
                          'content': 'ACADATA', 'arc5gl_query': 'ACA0',
-                         'fileglob': '*fits.gz'}
+                         'fileglob': 'aca*fits*'}
         :param start: start of interval to retrieve (Chandra.Time compatible)
         :param stop: end of interval to retrieve (Chandra.Time compatible)
 
@@ -739,7 +739,7 @@ class Updater(object):
         fetched_files = []
         ingest_dates = []
         # get the files, store in file archive, and record in database
-        for file in files:
+        for i, file in enumerate(files):
             # Retrieve CXC archive files in a temp directory with arc5gl
             missed_file = file['filename']
             arc5.sendline('dataset=flight')
@@ -750,9 +750,7 @@ class Updater(object):
             arc5.sendline('version=last')
             arc5.sendline('operation=retrieve')
             arc5.sendline('go')
-            have_files = sorted(glob(self.filetype['fileglob']))
-            if not len(have_files):
-                raise ValueError
+            have_files = sorted(glob(f"{missed_file}*"))
             filename = have_files[0]
             # if it isn't gzipped, just gzip it
             if re.match(r'.*\.fits$', filename):

--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -738,7 +738,7 @@ class Updater(object):
         fetched_files = []
         ingest_dates = []
         # get the files, store in file archive, and record in database
-        for i, file in enumerate(files):
+        for file in files:
             # Retrieve CXC archive files in a temp directory with arc5gl
             missed_file = file['filename']
             arc5.sendline('dataset=flight')

--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -14,8 +14,6 @@ import collections
 import tables
 from itertools import count
 from pathlib import Path
-import six
-from six.moves import zip
 
 import Ska.DBI
 import Ska.arc5gl
@@ -248,7 +246,7 @@ def get_l0_images(start, stop, slot, imgsize=None, columns=None):
         if sz < 8:
             imgraw = imgraw[:sz, :sz]
 
-        meta = {name: col[i] for name, col in six.iteritems(cols) if col[i] != -9999}
+        meta = {name: col[i] for name, col in cols.items() if col[i] != -9999}
         imgs.append(ACAImage(imgraw, meta=meta))
 
     return imgs

--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -767,14 +767,14 @@ class Updater(object):
 
     def _insert_files(self, files):
         count_inserted = 0
-        with Ska.DBI.DBI(**self.db) as db:
-            for i, f in enumerate(files):
-                arch_info = self._read_archfile(i, f, files)
-                if arch_info:
-                    self._move_archive_files([f])
+        for i, f in enumerate(files):
+            arch_info = self._read_archfile(i, f, files)
+            if arch_info:
+                self._move_archive_files([f])
+                with Ska.DBI.DBI(**self.db) as db:
                     db.insert(arch_info, 'archfiles')
-                    count_inserted += 1
-            db.commit()
+                    db.commit()
+                count_inserted += 1
         logger.info("Ingested %d files" % count_inserted)
 
     def update(self):


### PR DESCRIPTION
## Description

Fix some L0 ingest hiccups.  

The ingest code was failing to ingest single new files in Repro.  It looks like that was due to a bug in identifying new files that had been downloaded.  I also hit a db locking issue that was improved by reorganizing.  And while at it, I updated the pieces needed to make a new archive (of the list of files released.. the "cda" h5 piece) to work more happily with shiny (removed six, updated some urllib pieces).  I was not rigorous distinguishing reproV from shiny updates here as I have just been working in shiny.

## Testing

- [x] Passes mica archive l0 unit tests on Linux (a non-related L1 test looks to be failing now)
- [x] Functional testing - this worked in a test archive to ingest the files that were failing repeatedly with the flight code on the flight archive.  At this point I've also run the test code on the flight archive to just get the files in there.

