### PR TITLE
Increase an ASOL quat vs OBC quat test tolerance by 4 arcsecs in roll

### DIFF
--- a/mica/archive/tests/test_asp_l1.py
+++ b/mica/archive/tests/test_asp_l1.py
@@ -59,7 +59,7 @@ def test_get_atts_time():
     stop = '2014:005:00:00:00.000'
     atts, times, recs = asp_l1.get_atts(start=start, stop=stop)
     assert len(atts) == len(times)
-    compare_obc_and_asol(atts, times, recs, rtol=51)
+    compare_obc_and_asol(atts, times, recs, rtol=55)
     dwells = events.dwells.filter(start, stop)
     for dwell in dwells:
         if dwell.get_obsid() > 38000:


### PR DESCRIPTION
## Description

Increase an ASOL quat vs OBC quat test tolerance by 4 arcsecs in roll.

The test_get_atts_time code currently runs through a bunch of machinery to compare ASOL quat with OBC quats and asserts they are within some tolerances.  It looks like the released ReproV version of an ASOL in this time range has a sample that is 1 arcsec worse in roll.  I've increased the tolerance from 51 to 55 in the test in this PR.  I could also, for example, set the code to used a fixed version of the ASOLs, but we've recently removed "old" released ASOL files from the archive and we may continue to trim, so I think maybe it makes sense for this code always get the last released ASOL for the comparison.


## Testing

- [x] Passes unit tests on Linux

No functional testing.

Fixes #