### PR TITLE
A few small V&V and report updates

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -324,13 +324,14 @@ def obs_links(obsid, sequence=None, plan=None):
     else:
         mp_dir, status, mp_date = starcheck.get_mp_dir(obsid)
 
+
     # Check for centroid dashboard
     strobs = "%05d" % obsid
     chunk_dir = strobs[0:2]
     cen_dash_file = "{}/{}/index.html".format(chunk_dir, strobs)
-    if os.path.exists(os.path.join('/proj/sot/ska/www/ASPECT_ICXC/centroid_dashboard/',
+    if os.path.exists(os.path.join('/proj/sot/ska/www/ASPECT_ICXC/centroid_reports/',
                                    cen_dash_file)):
-        cen_url = 'https://icxc.cfa.harvard.edu/aspect/centroid_dashboard/'
+        cen_url = 'https://icxc.cfa.harvard.edu/aspect/centroid_reports/'
         links['cen_dash'] = {'link': "{}/{}".format(cen_url, cen_dash_file),
                             'label': 'Centroid Dashboard'}
 

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -324,7 +324,6 @@ def obs_links(obsid, sequence=None, plan=None):
     else:
         mp_dir, status, mp_date = starcheck.get_mp_dir(obsid)
 
-
     # Check for centroid dashboard
     strobs = "%05d" % obsid
     chunk_dir = strobs[0:2]

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -46,7 +46,7 @@ warnings.filterwarnings(
 
 
 WANT_VV_VERSION = 2
-REPORT_VERSION = 3
+REPORT_VERSION = 4
 
 plt.rcParams['lines.markeredgewidth'] = 0
 

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -1018,14 +1018,15 @@ class AspectInterval(object):
                                  slot=slot,
                                  id_string=str(ocat_info['id']),
                                  id_num=ocat_info['id'],
-                                 ang_y_nom=ocat_info['y_ang'],
-                                 ang_z_nom=ocat_info['z_ang'],
                                  mag_i_cmd=0,
                                  mag_i_avg=0,
                                  mag_i_min=0,
                                  mag_i_max=0,
                                  p_lsi=np.array([0,0,0]),
                                  )
+                if 'ang_y_nom' in self.fidprop.colnames:
+                    mock_prop['ang_y_nom'] = ocat_info['y_ang']
+                    mock_prop['ang_z_nom'] = ocat_info['z_ang']
                 self.fidprop.add_row(mock_prop)
                 self.fidpr_info.append(dict(slot=slot,
                                             tstart=self.asol_header['TSTART'],

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -43,7 +43,7 @@ class InconsistentAspectIntervals(ValueError):
     pass
 
 # integer code version for lightweight database tracking
-VV_VERSION = 3
+VV_VERSION = 4
 
 logger = logging.getLogger('vv')
 

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -6,7 +6,6 @@ import re
 import six
 import pickle
 import json
-import shelve
 import csv
 import gzip
 import logging
@@ -243,15 +242,6 @@ class Obi(object):
         logger.info("Saved JSON to {}".format(file))
 
 
-    def shelve_info(self, file):
-        if self.info()['aspect_1_id'] is None:
-            logger.warning("Shelving not implemented for obsids without aspect_1_ids")
-            return
-        s = shelve.open(file)
-        s["%s_%s" % (self.info()['obsid'], self.info()['revision'])] \
-            = self.info()
-        s.close()
-        logger.info("Saved to shelve file {}".format(file))
 
     def slots_to_db(self):
         if self.info()['aspect_1_id'] is None:

--- a/mica/vv/process.py
+++ b/mica/vv/process.py
@@ -211,11 +211,6 @@ def process(obsid, version='last'):
         return None
     obi.tempdir = tempfile.mkdtemp(dir=FILES['temp_root'])
     obi.save_plots_and_resid()
-    shelf_file = os.path.join(FILES['data_root'],
-                              FILES['shelf_file'])
-    if not os.path.exists(os.path.dirname(shelf_file)):
-        os.makedirs(os.path.dirname(shelf_file))
-    obi.shelve_info(shelf_file)
     _file_vv(obi)
     if not os.path.exists(FILES['h5_file']):
         vv_desc, byteorder = tables.descr_from_dtype(VV_DTYPE)


### PR DESCRIPTION
## Description

A few small V&V and mica.report updates.

This:

1. Updates the stored/saved version of the V&V entries made with the new code
2. Has a tiny fix to remove previous records in the V&V h5 table for a run if there were different numbers of slots saved (very unusual but should not stop processing)
3. Removes shelve support that was never really used
4. Adds a tiny fix to only add needed columns if "mocking up" a fidprop entry to do fid V&V on a fid that has been dropped from processing.
5. Is more rigorous opening and closing the V&V processing database as updates are done.
6. Updates version of report and fixes link to current centroid dashboard outputs


## Testing

- [x] Passes unit tests on Linux
- [x] Functional testing

With regard to functional testing, given how these data are used and given that we store the version information, I moved to  running this code in the "flight" mica archive.

