### PR TITLE
Fix script default to actually save plots

### DIFF
--- a/scripts/update_centroid_reports.py
+++ b/scripts/update_centroid_reports.py
@@ -3,4 +3,4 @@
 import mica.centroid_dashboard
 
 # Cheat. Needs entrypoint scripts
-mica.centroid_dashboard.update_observed_metrics()
+mica.centroid_dashboard.update_observed_metrics(save=True, make_plots=True)


### PR DESCRIPTION
## Description

Fix script default to actually save plots.

The real answer is to cleanup all the defaults and rethink the options in centroid_dashboard, combined with actual entry-point scripts.  But this fixes the current script to at least make the plots.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
   - ran this live on the real archive and I see plots made.

Fixes #