### PR TITLE
Skip report vv warn if no sybase passwd file for db

### DIFF
--- a/mica/report/tests/test_write_report.py
+++ b/mica/report/tests/test_write_report.py
@@ -9,15 +9,20 @@ from testr.test_helper import on_head_network, has_sybase
 
 from .. import report
 
+user = os.environ.get('USER') or os.environ.get('LOGNAME')
+
 try:
     import Ska.DBI
-    user = os.environ.get('USER') or os.environ.get('LOGNAME')
     with Ska.DBI.DBI(server='sqlsao', dbi='sybase', user=user, database='axafvv') as db:
         HAS_SYBASE_ACCESS = True
 except Exception:
-    if on_head_network() and not has_sybase():
-        warn("On HEAD but no sybase access. Run ska_envs or define SYBASE/SYBASE_OCS")
     HAS_SYBASE_ACCESS = False
+
+    # If the user should have access, warn about the issue.
+    if (on_head_network() and not has_sybase() and
+            os.path.exists(os.path.join(os.environ['SKA'], 'data', 'aspect_authorization',
+                                        f'sqlsao-axafvv-{user}'))):
+        warn("On HEAD but no sybase access. Run test from production environment.")
 
 
 HAS_SC_ARCHIVE = os.path.exists(report.starcheck.FILES['data_root'])

--- a/mica/report/tests/test_write_report.py
+++ b/mica/report/tests/test_write_report.py
@@ -1,6 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import tempfile
 import os
+from pathlib import Path
+import getpass
 import shutil
 import pytest
 from warnings import warn
@@ -9,7 +11,7 @@ from testr.test_helper import on_head_network, has_sybase
 
 from .. import report
 
-user = os.environ.get('USER') or os.environ.get('LOGNAME')
+user = getpass.getuser()
 
 try:
     import Ska.DBI
@@ -20,8 +22,8 @@ except Exception:
 
     # If the user should have access, warn about the issue.
     if (on_head_network() and not has_sybase() and
-            os.path.exists(os.path.join(os.environ['SKA'], 'data', 'aspect_authorization',
-                                        f'sqlsao-axafvv-{user}'))):
+            Path(os.environ['SKA'], 'data', 'aspect_authorization',
+                 f'sqlsao-axafvv-{user}').exists()):
         warn("On HEAD but no sybase access. Run test from production environment.")
 
 

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -1,7 +1,7 @@
 # Configuration file for task_schedule.pl 
 
 subject      Mica Tasks   # subject of email
-timeout      15000			  # Default tool timeout
+timeout      70000			  # Default tool timeout
 heartbeat_timeout 300			  # Maximum age of heartbeat file (seconds)
 loud         0				  # Run loudly
 iterations 1


### PR DESCRIPTION
## Description

Skip report vv warn if no sybase passwd file for db

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing
   - ran as jeanconn and kadi user on Linux from production ska3 and see test pass and test skip as appropriate

Fixes #