### PR TITLE
Disable use of agasc supplement for stats and a specific vv use case

### DIFF
--- a/mica/archive/tests/test_asp_l1.py
+++ b/mica/archive/tests/test_asp_l1.py
@@ -10,7 +10,7 @@ from .. import asp_l1
 
 HAS_L1_ARCHIVE = os.path.exists(asp_l1.CONFIG['data_root'])
 
-def compare_obc_and_asol(atts, times, recs, ptol=2, ytol=2, rtol=50):
+def compare_obc_and_asol(atts, times, recs, ptol=2, ytol=2, rtol=65):
     """
     Check that obc solution and ground solution have relatively close quats.
     Note that because the ground aspect solution is not continuous (only run over science obsids
@@ -59,7 +59,7 @@ def test_get_atts_time():
     stop = '2014:005:00:00:00.000'
     atts, times, recs = asp_l1.get_atts(start=start, stop=stop)
     assert len(atts) == len(times)
-    compare_obc_and_asol(atts, times, recs, rtol=55)
+    compare_obc_and_asol(atts, times, recs)
     dwells = events.dwells.filter(start, stop)
     for dwell in dwells:
         if dwell.get_obsid() > 38000:

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -148,7 +148,7 @@ def _deltas_vs_obc_quat(vals, times, catalog):
             logger.info("No agasc id for slot {}, skipping".format(slot))
             continue
         try:
-            star = agasc.get_star(agasc_id, date=times[0])
+            star = agasc.get_star(agasc_id, date=times[0], use_supplement=False)
         except:
             logger.info("agasc error on slot {}:{}".format(
                     slot, sys.exc_info()[0]))

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -179,7 +179,7 @@ def _deltas_vs_obc_quat(vals, times, catalog):
             continue
         try:
             # This is not perfect for star catalogs for agasc 1.4 and 1.5
-            star = agasc.get_star(agasc_id, date=times[0])
+            star = agasc.get_star(agasc_id, date=times[0], use_supplement=False)
         except:
             logger.info("agasc error on slot {}:{}".format(
                     slot, sys.exc_info()[0]))

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -1035,7 +1035,7 @@ class AspectInterval(object):
 
             if ocat_info['type'] == 1:
                 import agasc
-                star_info = agasc.get_star(ocat_info['id'])
+                star_info = agasc.get_star(ocat_info['id'], use_supplement=False)
                 mock_prop = dict(cel_loc_flag=0,
                                  id_status='OMITTED',
                                  agasc_id=ocat_info['id'],

--- a/mica/vv/tests/test_vv.py
+++ b/mica/vv/tests/test_vv.py
@@ -32,12 +32,12 @@ def test_get_rms_data():
 
 @pytest.mark.skipif('not HAS_VV_ARCHIVE', reason='Test requires vv archive')
 def test_get_vv():
-    obs = vv.get_vv(16504)
+    obs = vv.get_vv(16504, version=1)
     assert np.allclose(obs['slots']['7']['dz_rms'], 0.11610256063309182)
 
 @pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')
 def test_run_vv():
-    obi = process.get_arch_vv(2121)
+    obi = process.get_arch_vv(2121, version=3)
     assert np.allclose(obi.info()['sim']['max_d_dy'], 0.002197265625)
 
 @pytest.mark.skipif('not HAS_L1_ARCHIVE', reason='Test requires L1 archive')


### PR DESCRIPTION
## Description

Disable use of agasc supplement for stats and a specific vv use case
Also update a few vv tests newly failing due to repro.

## Testing

- [x] Passes unit tests on linux
- [ ] Functional testing

