### PR TITLE
Add get_star_stats single-star method for acq/gui stats and remove Sybase from mica.web.star_hist

### DIFF
--- a/mica/stats/acq_stats.py
+++ b/mica/stats/acq_stats.py
@@ -13,11 +13,10 @@ def get_stats(filter=True):
     :returns acq_stats: numpy.ndarray
     """
 
-    h5 = tables.open_file(TABLE_FILE, 'r')
-    stats = h5.root.data[:]
-    h5.close()
-    if filter:
-        stats = stats[~stats['known_bad']]
+    with tables.open_file(TABLE_FILE, 'r') as h5:
+        stats = h5.root.data[:]
+        if filter:
+            stats = stats[~stats['known_bad']]
     return stats
 
 
@@ -29,8 +28,8 @@ def get_star_stats(id, filter=True):
     :param filter: True filters out rows marked 'known_bad' in table
     :returns acq_stats: numpy.ndarray
     """
-    h5 = tables.open_file(TABLE_FILE, 'r')
-    stats = h5.root.data.read_where(f'agasc_id == {id}')
-    if filter:
-        stats = stats[~stats['known_bad']]
+    with tables.open_file(TABLE_FILE, 'r') as h5:
+        stats = h5.root.data.read_where(f'agasc_id == {id}')
+        if filter:
+            stats = stats[~stats['known_bad']]
     return stats

--- a/mica/stats/acq_stats.py
+++ b/mica/stats/acq_stats.py
@@ -19,3 +19,18 @@ def get_stats(filter=True):
     if filter:
         stats = stats[~stats['known_bad']]
     return stats
+
+
+def get_star_stats(id, filter=True):
+    """
+    Retrieve acq stats for agasc id
+
+    :param id: agasc id
+    :param filter: True filters out rows marked 'known_bad' in table
+    :returns acq_stats: numpy.ndarray
+    """
+    h5 = tables.open_file(TABLE_FILE, 'r')
+    stats = h5.root.data.read_where(f'agasc_id == {id}')
+    if filter:
+        stats = stats[~stats['known_bad']]
+    return stats

--- a/mica/stats/guide_stats.py
+++ b/mica/stats/guide_stats.py
@@ -21,3 +21,16 @@ def get_stats(filter=True):
     return stats
 
 
+def get_star_stats(id, filter=True):
+    """
+    Retrieve guide stats for agasc id
+
+    :param id: agasc id
+    :param filter: True filters out rows marked 'known_bad' in table
+    :returns stats: numpy.ndarray
+    """
+    h5 = tables.open_file(TABLE_FILE, 'r')
+    stats = h5.root.data.read_where(f'agasc_id == {id}')
+    if filter:
+        stats = stats[~stats['known_bad']]
+    return stats

--- a/mica/stats/guide_stats.py
+++ b/mica/stats/guide_stats.py
@@ -12,12 +12,10 @@ def get_stats(filter=True):
     :param filter: True filters out 'known_bad' rows from the table
     :returns gui_stats: numpy.ndarray
     """
-
-    h5 = tables.open_file(TABLE_FILE, 'r')
-    stats = h5.root.data[:]
-    h5.close()
-    if filter:
-        stats = stats[~stats['known_bad']]
+    with tables.open_file(TABLE_FILE, 'r') as h5:
+        stats = h5.root.data[:]
+        if filter:
+            stats = stats[~stats['known_bad']]
     return stats
 
 
@@ -29,8 +27,8 @@ def get_star_stats(id, filter=True):
     :param filter: True filters out rows marked 'known_bad' in table
     :returns stats: numpy.ndarray
     """
-    h5 = tables.open_file(TABLE_FILE, 'r')
-    stats = h5.root.data.read_where(f'agasc_id == {id}')
-    if filter:
-        stats = stats[~stats['known_bad']]
+    with tables.open_file(TABLE_FILE, 'r') as h5:
+        stats = h5.root.data.read_where(f'agasc_id == {id}')
+        if filter:
+            stats = stats[~stats['known_bad']]
     return stats

--- a/mica/stats/tests/test_acq_stats.py
+++ b/mica/stats/tests/test_acq_stats.py
@@ -12,14 +12,14 @@ HAS_OBSPAR_ARCHIVE = os.path.exists(
 HAS_ACQ_TABLE = Path(read_acq_stats.TABLE_FILE).exists()
 
 
-@pytest.mark.skipif('not HAS_ACQ_TABLE', reason='Test requires acq stats table')
-def read_single_star_stats():
+@pytest.mark.skipif(not HAS_ACQ_TABLE, reason='Test requires acq stats table')
+def test_single_star_stats():
     # Fetch the stats for the slot 5 BOT of obsid 5438 by id
     single = read_acq_stats.get_star_stats(839386400)
-    assert single[single['obsid'] == 5438]['acqid'][0] is True
+    assert single[single['obsid'] == 5438]['acqid'][0]
 
 
-@pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
+@pytest.mark.skipif(not HAS_OBSPAR_ARCHIVE, reason='Test requires mica obspars')
 def test_calc_stats():
     acq_stats.calc_stats(17210)
     acq_stats.calc_stats(15175)
@@ -27,7 +27,7 @@ def test_calc_stats():
     acq_stats.calc_stats(19386)
 
 
-@pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')
+@pytest.mark.skipif(not HAS_OBSPAR_ARCHIVE, reason='Test requires mica obspars')
 def test_make_acq_stats():
     """
     Save the acq stats for one obsid into a newly-created table

--- a/mica/stats/tests/test_acq_stats.py
+++ b/mica/stats/tests/test_acq_stats.py
@@ -2,11 +2,21 @@
 import tempfile
 import os
 import pytest
+from pathlib import Path
 
 from .. import update_acq_stats as acq_stats
+from .. import acq_stats as read_acq_stats
 
 HAS_OBSPAR_ARCHIVE = os.path.exists(
         acq_stats.mica.archive.obspar.CONFIG['data_root'])
+HAS_ACQ_TABLE = Path(read_acq_stats.TABLE_FILE).exists()
+
+
+@pytest.mark.skipif('not HAS_ACQ_TABLE', reason='Test requires acq stats table')
+def read_single_star_stats():
+    # Fetch the stats for the slot 5 BOT of obsid 5438 by id
+    single = read_acq_stats.get_star_stats(839386400)
+    assert single[single['obsid'] == 5438]['acqid'][0] is True
 
 
 @pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')

--- a/mica/stats/tests/test_guide_stats.py
+++ b/mica/stats/tests/test_guide_stats.py
@@ -16,6 +16,10 @@ def test_read_stats():
     slot = stats[(stats['obsid'] == 5438) & (stats['slot'] == 5)][0]
     np.isclose(slot['dy_std'], 0.16008819321078668)
     np.isclose(slot['dz_std'], 0.23807435722775061)
+    # Fetch the stats for the slot 5 BOT by id
+    single = guide_stats.get_star_stats(839386400)
+    np.isclose(single[single['obsid'] == 5438][0]['dy_std'], 0.16008819321078668)
+
 
 HAS_OBSPAR_ARCHIVE = os.path.exists(
         update_guide_stats.mica.archive.obspar.CONFIG['data_root'])

--- a/mica/web/templates/mica/star_hist.html
+++ b/mica/web/templates/mica/star_hist.html
@@ -95,6 +95,9 @@ table.pcad {border-spacing: 5px;}
 
 {% if gui_table %}
 <H3>Guide History</H3>
+<P><a href="{{ reports_url }}">agasc supplement report</a></P>
+
+<b>Old mica guide stats</b>
 <TABLE class='pcad' border=1>
 <tr>
 <th>date</th>

--- a/mica/web/views.py
+++ b/mica/web/views.py
@@ -72,8 +72,10 @@ class StarHistView(BaseView, TemplateView):
                 context['acq_table'] = acq_table
             if len(gui_table):
                 context['gui_table'] = gui_table
-
-
+                reports_url = (
+                    "https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/stars/"
+                    + f'{int(agasc_id//1e7):03d}/{agasc_id}/index.html')
+                context['reports_url'] = reports_url
         return context
 
 


### PR DESCRIPTION
## Description

Add some methods to do single star queries to the stats fetchers and update the mica.web star history piece to not use Sybase for guide stats.

## Testing

- [x] Passes unit tests on MacOS
- [x] Functional testing - two silly read-tests added for new methods.  

Not fully integration tested in kadi just yet.
