### PR TITLE
Skip tests if obspar data dirs not present

### DIFF
--- a/mica/stats/tests/test_acq_stats.py
+++ b/mica/stats/tests/test_acq_stats.py
@@ -7,8 +7,7 @@ from pathlib import Path
 from .. import update_acq_stats as acq_stats
 from .. import acq_stats as read_acq_stats
 
-HAS_OBSPAR_ARCHIVE = os.path.exists(
-        acq_stats.mica.archive.obspar.CONFIG['data_root'])
+HAS_OBSPAR_ARCHIVE = (Path(acq_stats.mica.archive.obspar.CONFIG['data_root']) / '00').exists()
 HAS_ACQ_TABLE = Path(read_acq_stats.TABLE_FILE).exists()
 
 

--- a/mica/stats/tests/test_guide_stats.py
+++ b/mica/stats/tests/test_guide_stats.py
@@ -3,6 +3,7 @@ import tempfile
 import os
 import numpy as np
 import pytest
+from pathlib import Path
 
 from .. import guide_stats
 from .. import update_guide_stats
@@ -21,8 +22,8 @@ def test_read_stats():
     np.isclose(single[single['obsid'] == 5438][0]['dy_std'], 0.16008819321078668)
 
 
-HAS_OBSPAR_ARCHIVE = os.path.exists(
-        update_guide_stats.mica.archive.obspar.CONFIG['data_root'])
+HAS_OBSPAR_ARCHIVE = (
+    Path(update_guide_stats.mica.archive.obspar.CONFIG['data_root']) / '00').exists()
 
 
 @pytest.mark.skipif('not HAS_OBSPAR_ARCHIVE', reason='Test requires mica obspars')


### PR DESCRIPTION
## Description

Update the "skip if no obspars" test for test skipping to skip if the '00' directory isn't present within the obspars directory.  The obspars directory with one database file is now sync'd as part of ska_sync but the data for the tests in the subdirectories isn't there.

## Testing

- [x] Passes unit tests on chimchim and skips the acq and guide tests correctly.
- [x] Functional testing

In this case the functional testing was the unit testing.  
