### PR TITLE
Retry aca0 web query and ignore gateway errors in log checks

### DIFF
--- a/mica/archive/cda_aca0_list.py
+++ b/mica/archive/cda_aca0_list.py
@@ -22,11 +22,12 @@ import tables
 from astropy.table import Table
 import numpy as np
 import urllib
-
-import time
-from Chandra.Time import DateTime
 import logging
 import argparse
+import time
+
+from ska_helpers.retry import retry_call
+from Chandra.Time import DateTime
 
 from mica.common import MICA_ARCHIVE
 
@@ -133,7 +134,8 @@ def update_cda_table(data_root=None,
     url = cda_fetch_url + query
     logger.info("URL for fetch {}".format(url))
     try:
-        new_lines = urllib.request.urlopen(url).read().decode().splitlines()
+        resp = retry_call(urllib.request.urlopen, [url], tries=5, delay=5)
+        new_lines = resp.read().decode().splitlines()
     except urllib.error.URLError as err:
         logger.info(err)
         return

--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -60,7 +60,8 @@ alert       aca@head.cfa.harvard.edu
           #    File           Expression
           #  ----------      ---------------------------
              mica_archive.log     Use of uninitialized value
-             mica_archive.log     error
+	     # No gateway time-out errors
+             mica_archive.log     error(?!.*Gateway Time-out.*)
              mica_archive.log     warning
              mica_archive.log     fatal
         </error>


### PR DESCRIPTION
## Description

Retry aca0 web query and ignore gateway errors in log checks

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing 

For functional testing I did a local edit (used a test URL that always returned an error) to test the retry.  

