### PR TITLE
Fix not track percent so it is not track percent

### DIFF
--- a/mica/web/star_hist.py
+++ b/mica/web/star_hist.py
@@ -56,7 +56,7 @@ def get_gui_data(agasc_id):
         srec['date'] = s['kalman_datestart']
         srec['mag'] = s['mag_aca']
         srec['mag_obs'] = s['aoacmag_mean']
-        srec['perc_not_track'] = s['f_track'] * 100.0
+        srec['perc_not_track'] = (1 - s['f_track']) * 100.0
         gui_table.append(srec)
     return gui_table
 


### PR DESCRIPTION
## Description

Fix not track percent so it is not track percent.
Silly bug.

## Testing

- [x] Passes unit tests on MacOS, linux, Windows (at least one required)
- [x] Functional testing

For functional testing, I ran the kadi (python manage.py runserver) test server at master with this teeny mica fix in my PYTHONPATH and confirmed that we now see reasonable values in the "% not track" column for guide star history.