### PR TITLE
Remove use of Ska.Shell

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -19,7 +19,6 @@ from astropy.table import Table
 from astropy.time import Time
 import astropy.units as u
 
-from Ska.Shell import bash
 import agasc
 import Ska.DBI
 from Chandra.Time import DateTime
@@ -652,7 +651,7 @@ def main(obsid):
             newfile = os.path.join(outdir, os.path.basename(file))
             if not os.path.exists(newfile):
                 logger.debug("linking {} into {}".format(file, outdir))
-                bash("ln -s {} {}".format(file, outdir))
+                os.symlink(file, newfile)
         asp_dir = asp_l1.get_obs_dirs(obsid)['last']
         asp_logs = sorted(glob(os.path.join(asp_dir, "asp_l1_f*log*gz")))
         for log, interval in zip(asp_logs, vv['intervals']):

--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -9,7 +9,6 @@ from pathlib import Path
 
 from six.moves import zip
 from Chandra.Time import DateTime
-import Ska.Shell
 import Ska.DBI
 
 from starcheck.parser import read_starcheck

--- a/mica/starcheck/tests/make_database.py
+++ b/mica/starcheck/tests/make_database.py
@@ -1,8 +1,8 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+import shutil
 import tempfile
 from Chandra.Time import DateTime
-from Ska.Shell import bash
 import mica.common
 
 # Override MICA_ARCHIVE with a temporary directory
@@ -17,4 +17,4 @@ config = mica.starcheck.process.DEFAULT_CONFIG
 config['start'] = DateTime() - 30
 mica.starcheck.process.update(config)
 # Cleanup manually
-bash("rm -r {}".format(TESTDIR))
+shutil.rmtree(TESTDIR)


### PR DESCRIPTION
## Description

Remove uses of Ska.Shell that can be handled with builtin functions.

## Interface impacts

None

## Testing

### Unit tests
- [x] Linux (on HEAD)

Independent check of unit tests by Jean
- [x] Linux

### Functional tests

- [x] Do the following on HEAD:
```
source /proj/sot/ska3/flight/bin/ska_envs.sh 
cd /proj/sot/ska/jgonzalez/git/mica
git fetch
git co ska-shell
export PYTHONPATH=`pwd`
cd test-pr-269/
```

and then in python:
```python
from mica.report import report
import getpass
import Ska.DBI
from pathlib import Path

user = getpass.getuser()
cwd = Path().absolute()
db = Ska.DBI.DBI(server='sqlsao', dbi='sybase', user=user, database='axafvv')  # as in test_write_reports
report.REPORT_ROOT = str(cwd)
report.REPORT_SERVER = str(cwd / 'test.db3')

for obsid in [20001, 15175, 54778]:
    report.main(obsid)
```
and check that all image links are there as expected (dir contents are the same as with the latest release and links are not broken).

Also checked that the bash history does not show the older `ln -s ...` statements.