### PR TITLE
Update ocat target table first in cron task

### DIFF
--- a/task_schedule.cfg
+++ b/task_schedule.cfg
@@ -45,6 +45,7 @@ alert       aca@head.cfa.harvard.edu
 <task mica_archive>
       cron       * * * * *
       check_cron * * * * *
+      exec 1: mica_update_ocat_target_table --datafile=$ENV{SKA}/data/mica/archive/ocat_target_table.h5
       exec 1: update_obspar.py
       exec 1: update_aca_l0.py
       exec 1: update_asp_l1.py
@@ -54,7 +55,6 @@ alert       aca@head.cfa.harvard.edu
       exec 1: update_guide_stats.py
       exec 1: update_vv.py
       exec 1: update_reports.py
-      exec 1: mica_update_ocat_target_table --datafile=$ENV{SKA}/data/mica/archive/ocat_target_table.h5
       context 1
       <check>
         <error>


### PR DESCRIPTION
## Description
Do the update for the ocat target table first in the cron task.

This can avoid an issue where another mica update task times out or has error.  The independent and quick ocat table update should just go first.  Of course other mica tasks should not have error or time out but that is a different issue.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->

## Interface impacts
None
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
None - this is all tested code and this task in the task schedule is not dependent on any of the other mica update steps.
<!-- If relevant describe any special setup for testing. -->

### Unit tests
Do not apply to this change as mica code was not changed.


### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
