### PR TITLE
Improve speed  of getting local OCAT data

### DIFF
--- a/mica/archive/cda/services.py
+++ b/mica/archive/cda/services.py
@@ -528,7 +528,7 @@ def update_ocat_local(datafile, **params):
             dat[name] = np.char.encode(col, 'utf-8')
 
     dat.write(datafile, path='data', serialize_meta=True, overwrite=True,
-              format='hdf5', compression=True)
+              format='hdf5', compression=False)
 
 
 def get_ocat_local(obsid=None, *,

--- a/mica/archive/cda/services.py
+++ b/mica/archive/cda/services.py
@@ -596,7 +596,25 @@ def get_ocat_local(obsid=None, *,
     for name, col in dat.columns.items():
         zero_length = len(dat) == 0
         if col.info.dtype.kind == 'S':
-            dat[name] = col.astype('U') if zero_length else np.char.decode(col, 'utf-8')
+            if zero_length:
+                dat[name] = col.astype('U')
+            else:
+                # Try a faster way of converting to unicode for ASCII input.
+                # View the column as a numpy array of bytes and look for values
+                # above 128 that signify a non-ASCII character.
+                itemsize = col.dtype.itemsize
+                col_bytes = col.view((np.uint8, (itemsize,)))
+                if np.all(col_bytes.flatten() < 128):
+                    # This is ASCII so the numpy UTF-8 version is just the same
+                    # but with the single leading byte set.
+                    col_utf8 = np.zeros((col_bytes.shape[0], itemsize * 4), dtype=np.uint8)
+                    for ii in range(itemsize):
+                        col_utf8[:, ii * 4] = col_bytes[:, ii]
+                    dat[name] = col_utf8.view(('U', itemsize)).flatten()
+                else:
+                    # Use the standard slow way for non-ASCII input. This can
+                    # run for pi_name and observer columns.
+                    dat[name] = np.char.decode(col, 'utf-8')
 
     # Match target_name as a substring of the table target_name column.
     if len(dat) > 0 and target_name is not None and not resolve_name:

--- a/mica/archive/cda/services.py
+++ b/mica/archive/cda/services.py
@@ -604,7 +604,7 @@ def get_ocat_local(obsid=None, *,
                 # above 128 that signify a non-ASCII character.
                 itemsize = col.dtype.itemsize
                 col_bytes = col.view((np.uint8, (itemsize,)))
-                if np.all(col_bytes.flatten() < 128):
+                if np.all(col_bytes < 128):
                     # This is ASCII so the numpy UTF-8 version is just the same
                     # but with the single leading byte set.
                     col_utf8 = np.zeros((col_bytes.shape[0], itemsize * 4), dtype=np.uint8)
@@ -612,8 +612,10 @@ def get_ocat_local(obsid=None, *,
                         col_utf8[:, ii * 4] = col_bytes[:, ii]
                     dat[name] = col_utf8.view(('U', itemsize)).flatten()
                 else:
-                    # Use the standard slow way for non-ASCII input. This can
-                    # run for pi_name and observer columns.
+                    # Use the standard slow way for non-ASCII input. This is
+                    # commonly run for pi_name and observer columns that have
+                    # names with unicode characters, but it might run for other
+                    # columns since we have no spec on OCAT data content.
                     dat[name] = np.char.decode(col, 'utf-8')
 
     # Match target_name as a substring of the table target_name column.

--- a/mica/archive/tests/test_cda.py
+++ b/mica/archive/tests/test_cda.py
@@ -94,6 +94,13 @@ def test_ocat_details_local_where(datafile):
     assert all('JET' in row['target_name'] for row in dat)
 
 
+def test_ocat_local_unicode():
+    """Unicode converstion from H5 encoding to UTF-8 is working"""
+    dat = get_ocat_local()
+    for key in ('observer', 'pi_name'):
+        assert np.any('ü' in val for val in dat[key])
+
+
 def test_ocat_special_query():
     dat = get_ocat_web(obsid=8008, rollReqs='true')
     assert len(dat) == 1


### PR DESCRIPTION
## Description

Improve the speed of reading the local OCAT. Most of the time is spent decoding the UTF-8

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Javier

### Functional tests

#### Current release
```
(ska3) ➜  docs git:(ocat-local-faster) ipython
Python 3.8.12 (default, Oct 12 2021, 06:23:56) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.29.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from mica.archive.cda import get_ocat_local
In [2]: %time dat = get_ocat_local()
CPU times: user 1.69 s, sys: 83 ms, total: 1.77 s
Wall time: 1.77 s
```

#### New using current compressed HDF5
```
(ska3) ➜  mica git:(ocat-local-faster) ipython
Python 3.8.12 (default, Oct 12 2021, 06:23:56) 
Type 'copyright', 'credits' or 'license' for more information
IPython 7.29.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from mica.archive.cda import get_ocat_local
In [2]: %time dat = get_ocat_local()
CPU times: user 456 ms, sys: 93.3 ms, total: 549 ms
Wall time: 549 ms
```

#### New using uncompressed HDF5
```
In [2]: %time dat = get_ocat_local(datafile="ocat.h5")
CPU times: user 298 ms, sys: 103 ms, total: 401 ms
Wall time: 403 ms
```