### PR TITLE
Added vectorized versions of some archive.dark_cal functions

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -68,7 +68,7 @@ def get_dark_cal_dirs(dark_cals_dir=MICA_FILES['dark_cals_dir'].abs):
     Get an ordered dict of directory paths containing dark current calibration files,
     where the key is the dark cal identifier (YYYYDOY) and the value is the path.
 
-    :param source: source of dark cal directories ('mica'|'ska')
+    :param dark_cals_dir: directory containing dark cals.
     :returns: ordered dict of absolute directory paths
     """
     dark_cal_ids = sorted([fn for fn in os.listdir(dark_cals_dir)
@@ -76,6 +76,20 @@ def get_dark_cal_dirs(dark_cals_dir=MICA_FILES['dark_cals_dir'].abs):
     dark_cal_dirs = [os.path.join(dark_cals_dir, id_)
                      for id_ in dark_cal_ids]
     return OrderedDict(zip(dark_cal_ids, dark_cal_dirs))
+
+
+@lru_cache()
+def get_dark_cal_ids(dark_cals_dir=MICA_FILES['dark_cals_dir'].abs):
+    """
+    Get an ordered dict dates as keys and dark cal identifiers (YYYYDOY) as values.
+
+    :param dark_cals_dir: directory containing dark cals.
+    :returns: ordered dict of absolute directory paths
+    """
+    dark_cal_ids = sorted([fn for fn in os.listdir(dark_cals_dir)
+                           if re.match(r'[12]\d{6}$', fn)])
+    dates = [CxoTime(d[:4] + ':' + d[4:]).date for d in dark_cal_ids]
+    return OrderedDict(zip(dates, dark_cal_ids))
 
 
 def get_dark_cal_id(date, select='before'):
@@ -118,7 +132,7 @@ def _get_dark_cal_id_scalar(date, select='before'):
     if ii < 0:
         earliest = CxoTime(dark_cal_secs[0]).date[:8]
         raise ValueError(
-            f'trying to get last dark cal before {date}, '
+            f'trying to get last dark cal on {date}, '
             f'which is before the earliest dark cal on {earliest}'
         )
 

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -115,6 +115,13 @@ def _get_dark_cal_id_scalar(date, select='before'):
     else:
         raise ValueError('select arg must be one of "nearest", "before", or "after"')
 
+    if ii < 0:
+        earliest = CxoTime(dark_cal_secs[0]).date[:8]
+        raise ValueError(
+            f'trying to get last dark cal before {date}, '
+            f'which is before the earliest dark cal on {earliest}'
+        )
+
     try:
         out_dark_id = dark_cal_ids[ii]
     except IndexError:

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -39,10 +39,10 @@ def date_to_dark_id(date):
     if not time.shape:
         return date_str[:4] + date_str[5:8]
     date_str = np.atleast_1d(date_str)
-    b = date_str.view((str, 1)).reshape(-1, date_str.dtype.itemsize // 4)
-    b = np.hstack([b[:, :4], b[:, 5:8]])
-    b = np.frombuffer(b.tobytes(), dtype=(str, 7))
-    return b.reshape(time.shape)
+    chars = date_str.view((str, 1)).reshape(-1, date_str.dtype.itemsize // 4)
+    result = np.hstack([chars[:, :4], chars[:, 5:8]])
+    result = np.frombuffer(result.tobytes(), dtype=(str, 7))
+    return result.reshape(time.shape)
 
 
 def dark_id_to_date(dark_id):

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -11,7 +11,7 @@ import numpy as np
 from astropy.io import fits, ascii
 from astropy.table import Column
 import pyyaks.context
-from Chandra.Time import DateTime
+from cxotime import CxoTime
 from chandra_aca.aca_image import ACAImage
 
 from chandra_aca.dark_model import dark_temp_scale, DARK_SCALE_4C
@@ -30,21 +30,34 @@ def date_to_dark_id(date):
     """
     Convert ``date`` to the corresponding YYYYDOY format for a dark cal identifiers.
 
-    :param date: any DateTime compatible format
+    :param date: any CxoTime compatible format
     :returns: dark id (YYYYDOY)
     """
-    date = DateTime(date).date
-    return date[:4] + date[5:8]
+    t = CxoTime(date)
+    shape = np.shape(t)
+    if not shape:
+        return t.date[:4] + t.date[5:8]
+    b = t.date.view((str, 1)).reshape(-1, 21)
+    b = np.hstack([b[:, :4], b[:, 5:8]])
+    b = np.frombuffer(b.tobytes(), dtype=(str, 7))
+    return b.reshape(shape)
 
 
 def dark_id_to_date(dark_id):
     """
-    Convert ``dark_id`` (YYYYDOY) to the corresponding DateTime 'date' format.
+    Convert ``dark_id`` (YYYYDOY) to the corresponding CxoTime 'date' format.
 
     :param date: dark id (YYYYDOY)
-    :returns: str in DateTime 'date' format
+    :returns: str in CxoTime 'date' format
     """
-    return '{}:{}'.format(dark_id[:4], dark_id[4:])
+    shape = np.shape(dark_id)
+    if not shape:
+        return '{}:{}'.format(dark_id[:4], dark_id[4:])
+    b = np.atleast_1d(dark_id).view((str, 1)).reshape(-1, 7)
+    sep = np.array([':'] * len(b))[:, None]
+    b = np.hstack([b[:, :4], sep, b[:, 4:]])
+    b = np.frombuffer(b.tobytes(), dtype=(str, 8))
+    return b.reshape(shape)
 
 
 @lru_cache()
@@ -70,12 +83,15 @@ def get_dark_cal_id(date, select='before'):
     If ``select`` is ``'before'`` (default) then use the first calibration which
     occurs before ``date``.  Other valid options are ``'after'`` and ``'nearest'``.
 
-    :param date: date in any DateTime format
+    :param date: date in any CxoTime format
     :param select: method to select dark cal (before|nearest|after)
 
     :returns: dark cal id string (YYYYDOY)
     """
+    return _get_dark_cal_id_vector(date, select=select)
 
+
+def _get_dark_cal_id_scalar(date, select='before'):
     dark_cals = get_dark_cal_dirs()
     dark_id = date_to_dark_id(date)
 
@@ -85,8 +101,8 @@ def get_dark_cal_id(date, select='before'):
         return dark_id
 
     dark_cal_ids = list(dark_cals.keys())
-    date_secs = DateTime(date).secs
-    dark_cal_secs = DateTime(np.array([dark_id_to_date(id_) for id_ in dark_cal_ids])).secs
+    date_secs = CxoTime(date).secs
+    dark_cal_secs = CxoTime(np.array([dark_id_to_date(id_) for id_ in dark_cal_ids])).secs
 
     if select == 'nearest':
         ii = np.argmin(np.abs(dark_cal_secs - date_secs))
@@ -105,6 +121,9 @@ def get_dark_cal_id(date, select='before'):
     return out_dark_id
 
 
+_get_dark_cal_id_vector = np.vectorize(_get_dark_cal_id_scalar, excluded=['select'])
+
+
 @DARK_CAL.cache
 def _get_dark_cal_image_props(date, select='before', t_ccd_ref=None, aca_image=False,
                               allow_negative=False):
@@ -112,7 +131,7 @@ def _get_dark_cal_image_props(date, select='before', t_ccd_ref=None, aca_image=F
     Return the dark calibration image (e-/s) nearest to ``date`` and the corresponding
     dark_props file.
 
-    :param date: date in any DateTime format
+    :param date: date in any CxoTime format
     :param select: method to select dark cal (before|nearest|after)
     :param t_ccd_ref: rescale dark map to temperature (degC, default=no scaling)
     :param aca_image: return an AcaImage instance
@@ -164,7 +183,7 @@ def get_dark_cal_image(date, select='before', t_ccd_ref=None, aca_image=False,
     If ``select`` is ``'before'`` (default) then use the first calibration which
     occurs before ``date``.  Other valid options are ``'after'`` and ``'nearest'``.
 
-    :param date: date in any DateTime format
+    :param date: date in any CxoTime format
     :param select: method to select dark cal (before|nearest|after)
     :param t_ccd_ref: rescale dark map to temperature (degC, default=no scaling)
     :param aca_image: return an ACAImage instance instead of ndarray
@@ -189,7 +208,7 @@ def get_dark_cal_props(date, select='before', include_image=False, t_ccd_ref=Non
     If ``include_image`` is True then an additional column or key ``image`` is
     defined which contains the corresponding 1024x1024 dark cal image.
 
-    :param date: date in any DateTime format
+    :param date: date in any CxoTime format
     :param select: method to select dark cal (before|nearest|after)
     :param include_image: include the dark cal images in output (default=False)
     :param t_ccd_ref: rescale dark map to temperature (degC, default=no scaling)

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -14,7 +14,8 @@ import pyyaks.context
 from cxotime import CxoTime
 from chandra_aca.aca_image import ACAImage
 
-from chandra_aca.dark_model import dark_temp_scale, DARK_SCALE_4C
+from chandra_aca.dark_model import dark_temp_scale
+from chandra_aca.dark_model import DARK_SCALE_4C  # noqa
 from mica.cache import lru_cache
 from mica.common import MICA_ARCHIVE_PATH, MissingDataError
 from . import file_defs

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -34,14 +34,15 @@ def date_to_dark_id(date):
     :param date: any CxoTime compatible format
     :returns: dark id (YYYYDOY)
     """
-    t = CxoTime(date)
-    shape = np.shape(t)
-    if not shape:
-        return t.date[:4] + t.date[5:8]
-    b = t.date.view((str, 1)).reshape(-1, 21)
+    time = CxoTime(date)
+    date_str = time.date
+    if not time.shape:
+        return date_str[:4] + date_str[5:8]
+    date_str = np.atleast_1d(date_str)
+    b = date_str.view((str, 1)).reshape(-1, date_str.dtype.itemsize // 4)
     b = np.hstack([b[:, :4], b[:, 5:8]])
     b = np.frombuffer(b.tobytes(), dtype=(str, 7))
-    return b.reshape(shape)
+    return b.reshape(time.shape)
 
 
 def dark_id_to_date(dark_id):

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -131,9 +131,9 @@ def _get_dark_cal_id_scalar(date, select='before'):
 
     if ii < 0:
         earliest = CxoTime(dark_cal_secs[0]).date[:8]
-        raise ValueError(
-            f'trying to get last dark cal on {date}, '
-            f'which is before the earliest dark cal on {earliest}'
+        raise MissingDataError(
+            f'No dark cal found before {earliest}'
+            f'(requested dark cal on {date})'
         )
 
     try:

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -125,3 +125,8 @@ def test_vectorized():
     dark_cal_id = dark_cal.get_dark_cal_id(['2022:100', '2022:105', '2022:127'], 'nearest')
     assert np.all(dark_cal_id_ref == dark_cal_id)
 
+
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
+def test_lower_limit():
+    with pytest.raises(ValueError, match='trying to get last dark cal on'):
+        dark_cal.get_dark_cal_id('2000:001')

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -131,9 +131,10 @@ def test_vectorized():
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_limits():
-    with pytest.raises(MissingDataError, match='No dark cal found before'):
-        dark_cal.get_dark_cal_id('2000:001', 'before')
     dark_cal_ids = dark_cal.get_dark_cal_ids()
+    first = cxotime.CxoTime(list(dark_cal_ids.keys())[0]) - 1 * cxotime.units.day
+    with pytest.raises(MissingDataError, match='No dark cal found before'):
+        dark_cal.get_dark_cal_id(first, 'before')
     last = cxotime.CxoTime(list(dark_cal_ids.keys())[-1]) + 1 * cxotime.units.day
     with pytest.raises(MissingDataError, match='No dark cal found after'):
         dark_cal.get_dark_cal_id(last, 'after')

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -138,7 +138,3 @@ def test_limits():
     last = cxotime.CxoTime(list(dark_cal_ids.keys())[-1]) + 1 * cxotime.units.day
     with pytest.raises(MissingDataError, match='No dark cal found after'):
         dark_cal.get_dark_cal_id(last, 'after')
-
-
-def test_bla():
-    t = CxoTime('2025:001')

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -6,8 +6,11 @@ import os
 import numpy as np
 import pytest
 
+import cxotime
 from ..aca_dark import dark_cal
 from chandra_aca.aca_image import ACAImage
+
+from mica.common import MissingDataError
 
 HAS_DARK_ARCHIVE = os.path.exists(dark_cal.MICA_FILES['dark_cals_dir'].abs)
 
@@ -127,6 +130,14 @@ def test_vectorized():
 
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
-def test_lower_limit():
-    with pytest.raises(ValueError, match='trying to get last dark cal on'):
-        dark_cal.get_dark_cal_id('2000:001')
+def test_limits():
+    with pytest.raises(MissingDataError, match='No dark cal found before'):
+        dark_cal.get_dark_cal_id('2000:001', 'before')
+    dark_cal_ids = dark_cal.get_dark_cal_ids()
+    last = cxotime.CxoTime(list(dark_cal_ids.keys())[-1]) + 1 * cxotime.units.day
+    with pytest.raises(MissingDataError, match='No dark cal found after'):
+        dark_cal.get_dark_cal_id(last, 'after')
+
+
+def test_bla():
+    t = CxoTime('2025:001')

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -104,3 +104,24 @@ def test_get_dark_cal_props_table_mixed():
     assert props.colnames == ['ccd_temp', 'date', 'dec', 'dur', 'eb', 'el', 'id', 'l_l0',
                               'ra', 'start', 'stop', 'sun_el', 'zodib', 't_ccd',
                               'n_ccd_img', 'datestart', 'datestop', 'filename']
+
+
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
+def test_vectorized():
+    dark_id_ref = ['2022100', '2022105', '2022127']
+    date_ref = ['2022:100', '2022:105', '2022:127']
+    assert np.all(dark_id_ref == dark_cal.date_to_dark_id(date_ref))
+    assert np.all(date_ref == dark_cal.dark_id_to_date(dark_id_ref))
+
+    dark_cal_id_ref = ['2022069', '2022104', '2022104']
+    dark_cal_id = dark_cal.get_dark_cal_id(['2022:100', '2022:105', '2022:127'], 'before')
+    assert np.all(dark_cal_id_ref == dark_cal_id)
+
+    dark_cal_id_ref = ['2022104', '2022133', '2022133']
+    dark_cal_id = dark_cal.get_dark_cal_id(['2022:100', '2022:105', '2022:127'], 'after')
+    assert np.all(dark_cal_id_ref == dark_cal_id)
+
+    dark_cal_id_ref = ['2022104', '2022104', '2022133']
+    dark_cal_id = dark_cal.get_dark_cal_id(['2022:100', '2022:105', '2022:127'], 'nearest')
+    assert np.all(dark_cal_id_ref == dark_cal_id)
+


### PR DESCRIPTION
## Description

This PR adds vectorized versions of get_dark_cal_id, date_to_dark_id and dark_id_to_date. It also replaces the uses of DateTime by CxoTime inside `mica.archive.aca_dark.dark_cal` (all other uses of `DateTime` were left there).

## Interface impacts
Everything *should* be backward compatible. This only enhances the interface, so something like this is possible:
```
get_dark_cal_id(['2022:100', '2022:105', '2022:127'], 'before')
```

## Testing


### Unit tests

I added a test for these vectorized functions.

- [x] Mac

Independent check of unit tests by @jeanconn 
- [x] Linux

### Functional tests

No functional testing.
