### PR TITLE
Fix issue in vectorized get_dark_cal_id

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -107,7 +107,7 @@ def get_dark_cal_id(date, select='before'):
     dark_id = _get_dark_cal_id_vector(date, select=select)
     if not dark_id.shape:
         # returning an instance of the type, not a numpy array
-        return dark_id.dtype.type(dark_id)
+        return dark_id.tolist()
     return dark_id
 
 

--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -104,7 +104,11 @@ def get_dark_cal_id(date, select='before'):
 
     :returns: dark cal id string (YYYYDOY)
     """
-    return _get_dark_cal_id_vector(date, select=select)
+    dark_id = _get_dark_cal_id_vector(date, select=select)
+    if not dark_id.shape:
+        # returning an instance of the type, not a numpy array
+        return dark_id.dtype.type(dark_id)
+    return dark_id
 
 
 def _get_dark_cal_id_scalar(date, select='before'):

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -110,6 +110,12 @@ def test_get_dark_cal_props_table_mixed():
 
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
+def test_scalar():
+    dark_cal_id = dark_cal.get_dark_cal_id('2022:100')
+    assert dark_cal_id[:4] == '2022' and dark_cal_id[4:] == '069'
+
+
+@pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 def test_vectorized():
     dark_id_ref = ['2022100', '2022105', '2022127']
     date_ref = ['2022:100', '2022:105', '2022:127']


### PR DESCRIPTION
## Description

This fixes a bug found in regression testing. `get_dark_cal_id` is vectorized using `np.vectorize`. When the input is a scalar, it returns a numpy scalar, but that is a numpy array with shape `()`. This has overloaded the bracket operators, so you can't call the bracket operators on the result. The solution is to return a scalar of the dtype's type.

## Interface impacts
None

## Testing
mica unit tests and sparkles tests pass (including a new test for this)

### Unit tests

- [x] Mac

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

