### PR TITLE
add optional dark_cal_ids argument to dark_cal.get_dark_cal_id

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -92,7 +92,7 @@ def get_dark_cal_ids(dark_cals_dir=MICA_FILES['dark_cals_dir'].abs):
     return OrderedDict(zip(dates, dark_cal_ids))
 
 
-def get_dark_cal_id(date, select='before'):
+def get_dark_cal_id(date, select='before', dark_cal_ids=None):
     """
     Return the dark calibration id corresponding to ``date``.
 
@@ -101,26 +101,27 @@ def get_dark_cal_id(date, select='before'):
 
     :param date: date in any CxoTime format
     :param select: method to select dark cal (before|nearest|after)
+    :param dark_cal_ids: list of all dark-cal IDs (optional, the output of get_dark_cal_ids)
 
     :returns: dark cal id string (YYYYDOY)
     """
-    dark_id = _get_dark_cal_id_vector(date, select=select)
+    dark_id = _get_dark_cal_id_vector(date, select=select, dark_cal_ids=dark_cal_ids)
     if not dark_id.shape:
         # returning an instance of the type, not a numpy array
         return dark_id.tolist()
     return dark_id
 
 
-def _get_dark_cal_id_scalar(date, select='before'):
-    dark_cals = get_dark_cal_dirs()
+def _get_dark_cal_id_scalar(date, select='before', dark_cal_ids=None):
+    if dark_cal_ids is None:
+        dark_cal_ids = list(get_dark_cal_dirs().keys())
     dark_id = date_to_dark_id(date)
 
     # Special case if dark_id is exactly an existing dark cal then return that dark
     # cal regardless of the select method.
-    if dark_id in dark_cals:
+    if dark_id in dark_cal_ids:
         return dark_id
 
-    dark_cal_ids = list(dark_cals.keys())
     date_secs = CxoTime(date).secs
     dark_cal_secs = CxoTime(np.array([dark_id_to_date(id_) for id_ in dark_cal_ids])).secs
 
@@ -148,7 +149,7 @@ def _get_dark_cal_id_scalar(date, select='before'):
     return out_dark_id
 
 
-_get_dark_cal_id_vector = np.vectorize(_get_dark_cal_id_scalar, excluded=['select'])
+_get_dark_cal_id_vector = np.vectorize(_get_dark_cal_id_scalar, excluded=['select', 'dark_cal_ids'])
 
 
 @DARK_CAL.cache

--- a/mica/archive/tests/test_aca_dark_cal.py
+++ b/mica/archive/tests/test_aca_dark_cal.py
@@ -39,6 +39,21 @@ def test_get_dark_cal_id():
     assert dark_cal.get_dark_cal_id('2007:008:12:00:00', 'before') == '2007006'
     assert dark_cal.get_dark_cal_id('2007:008:12:00:00', 'after') == '2007069'
 
+    dark_cal_ids = list(dark_cal.get_dark_cal_ids().values())
+    # removing these two to make sure it is not like the default case
+    dark_cal_ids.remove('2007006')
+    dark_cal_ids.remove('2007069')
+
+    assert dark_cal.get_dark_cal_id(
+        '2007:008:12:00:00', 'nearest', dark_cal_ids=dark_cal_ids
+    ) == '2006329'
+    assert dark_cal.get_dark_cal_id(
+        '2007:008:12:00:00', 'before', dark_cal_ids=dark_cal_ids
+    ) == '2006329'
+    assert dark_cal.get_dark_cal_id(
+        '2007:008:12:00:00', 'after', dark_cal_ids=dark_cal_ids
+    ) == '2007251'
+
 
 @pytest.mark.skipif('not HAS_DARK_ARCHIVE', reason='Test requires dark archive')
 @pytest.mark.parametrize('allow_negative', [True, False])


### PR DESCRIPTION
## Description

This PR adds an optional argument to `dark_cal.get_dark_cal_id`. Normally one calls this function like this:
```
dark_cal.get_dark_cal_id(time, 'before')
```
and internally it checks all dark-cal IDs to see which one is "closer" according to the given selection criterion. After this change, one will be able to do
```
dark_cal_ids = dark_cal.get_dark_cal_ids()
dark_cal.get_dark_cal_id(time, 'before', dark_cal_ids=dark_cal_ids)
```

The reason for this is that I am modifying aca_view to fetch data from the Ska API, and I would like to reduce the number of calls to the API. In the first call above, one gets the dark-cal ID for a given time, and the call might be repeated many times. This is unnecessary  because in most cases there will only be one dark-cal ID that applies to all times.

I would rather get the whole list of dark-cal IDs from the API upfront, and then call the `get_dark_cal_id` method locally for all times.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests

Unit tests were improved to include this new argument:

- [x] Mac


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

I have been using this from aca_view.
