### PR TITLE
starcheck subpackage: apply black and isort, fix line lengths, remove unused imports

### DIFF
--- a/mica/starcheck/__init__.py
+++ b/mica/starcheck/__init__.py
@@ -1,3 +1,10 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-from .starcheck import (get_starcheck_catalog, get_starcheck_catalog_at_date,
-                        get_mp_dir, get_monitor_windows, get_dither, get_att, get_starcat)
+from .starcheck import (
+    get_starcheck_catalog,
+    get_starcheck_catalog_at_date,
+    get_mp_dir,
+    get_monitor_windows,
+    get_dither,
+    get_att,
+    get_starcat,
+)

--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -160,7 +160,7 @@ def update(config=None):
         logger.info("Attempting ingest of %s" % st)
         # get an existing id or insert a new one
         mp_dir = re.search(
-            "\/data\/mpcrit1\/mplogs(\/\d{4}\/\w{7}/\w{5}\/)starcheck.txt", st
+            r"/data/mpcrit1/mplogs(/\d{4}/\w{7}/\w{5}/)starcheck.txt", st
         ).group(1)
         idcheck = db.fetchone("select id from starcheck_id where dir = '%s'" % mp_dir)
         existing = None

--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -1,96 +1,87 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import argparse
+import logging
 import os
 import re
-import logging
-import argparse
 from itertools import count
 from operator import itemgetter
 from pathlib import Path
 
-from six.moves import zip
-from Chandra.Time import DateTime
 import Ska.DBI
-
+from Chandra.Time import DateTime
 from starcheck.parser import read_starcheck
+
 from mica.common import MICA_ARCHIVE
 
-logger = logging.getLogger('starcheck ingest')
+logger = logging.getLogger("starcheck ingest")
 logger.setLevel(logging.INFO)
 logger.addHandler(logging.StreamHandler())
 
-DEFAULT_CONFIG = dict(starcheck_db=dict(dbi='sqlite',
-                                        server=os.path.join(MICA_ARCHIVE, 'starcheck', 'starcheck.db3')),
-                      mp_top_level='/data/mpcrit1/mplogs',
-                      timelines_db=dict(dbi='sqlite',
-                                        server=os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')))
-FILES = dict(data_root=os.path.join(MICA_ARCHIVE, 'starcheck'),
-             sql_def='starcheck.sql')
-
+DEFAULT_CONFIG = dict(
+    starcheck_db=dict(
+        dbi="sqlite", server=os.path.join(MICA_ARCHIVE, "starcheck", "starcheck.db3")
+    ),
+    mp_top_level="/data/mpcrit1/mplogs",
+    timelines_db=dict(
+        dbi="sqlite",
+        server=os.path.join(os.environ["SKA"], "data", "cmd_states", "cmd_states.db3"),
+    ),
+)
+FILES = dict(data_root=os.path.join(MICA_ARCHIVE, "starcheck"), sql_def="starcheck.sql")
 
 
 def ingest_obs(obs, obs_idx, sc_id, st, db, existing=None):
     if existing is not None:
-        existing_obs = [eobs for eobs in existing
-                        if eobs['obsid'] == int(obs['obsid'])]
+        existing_obs = [eobs for eobs in existing if eobs["obsid"] == int(obs["obsid"])]
         if len(existing_obs):
-            logger.debug(
-                "Skipping ingest of %s %d" % (st, int(obs['obsid'])))
+            logger.debug("Skipping ingest of %s %d" % (st, int(obs["obsid"])))
             return
-    obs_d = obs['obs']
-    obs_d.update(dict(sc_id=sc_id,
-                      obs_idx=obs_idx))
-    if obs_d.get('sim_z_offset_steps') is not None:
-        obs_d['sim_z_offset_mm'] = (
-            float(obs['obs'].get('sim_z_offset_steps'))
-            * 1000
-            * 2.51432e-06)
-    logger.debug("inserting obs %s from %s" % (obs['obsid'], st))
-    db.insert(obs_d, 'starcheck_obs')
-    for manvr in obs['manvrs']:
-        logger.debug("inserting manvr at %s" % manvr['mp_targquat_time'])
+    obs_d = obs["obs"]
+    obs_d.update(dict(sc_id=sc_id, obs_idx=obs_idx))
+    if obs_d.get("sim_z_offset_steps") is not None:
+        obs_d["sim_z_offset_mm"] = (
+            float(obs["obs"].get("sim_z_offset_steps")) * 1000 * 2.51432e-06
+        )
+    logger.debug("inserting obs %s from %s" % (obs["obsid"], st))
+    db.insert(obs_d, "starcheck_obs")
+    for manvr in obs["manvrs"]:
+        logger.debug("inserting manvr at %s" % manvr["mp_targquat_time"])
         db.insert(
-            dict(
-                sc_id=sc_id,
-                obsid=obs['obsid'],
-                obs_idx=obs_idx,
-                **manvr),
-            'starcheck_manvr')
-    for star in obs['catalog']:
+            dict(sc_id=sc_id, obsid=obs["obsid"], obs_idx=obs_idx, **manvr),
+            "starcheck_manvr",
+        )
+    for star in obs["catalog"]:
         star_d = dict(
             sc_id=sc_id,
-            obsid=obs['obsid'],
+            obsid=obs["obsid"],
             obs_idx=obs_idx,
-            mp_starcat_time=obs['obs']['mp_starcat_time'],
-            **star)
-        logger.debug("inserting %s idx of catalog" % star['idx'])
-        db.insert(star_d, 'starcheck_catalog')
-    logger.debug("inserting %d warnings" % len(obs['warnings']))
-    for warn in obs['warnings']:
-        warn_d = dict(
-            sc_id=sc_id,
-            obsid=obs['obsid'],
-            obs_idx=obs_idx,
-            **warn)
-        db.insert(warn_d, 'starcheck_warnings')
-    if obs['pred_ccd_temp'] is not None:
-        db.insert(dict(sc_id=sc_id, obsid=obs['obsid'], pred_ccd_temp=obs['pred_ccd_temp']),
-                  'starcheck_pred_temp')
+            mp_starcat_time=obs["obs"]["mp_starcat_time"],
+            **star
+        )
+        logger.debug("inserting %s idx of catalog" % star["idx"])
+        db.insert(star_d, "starcheck_catalog")
+    logger.debug("inserting %d warnings" % len(obs["warnings"]))
+    for warn in obs["warnings"]:
+        warn_d = dict(sc_id=sc_id, obsid=obs["obsid"], obs_idx=obs_idx, **warn)
+        db.insert(warn_d, "starcheck_warnings")
+    if obs["pred_ccd_temp"] is not None:
+        db.insert(
+            dict(sc_id=sc_id, obsid=obs["obsid"], pred_ccd_temp=obs["pred_ccd_temp"]),
+            "starcheck_pred_temp",
+        )
     db.commit()
 
 
 def get_options():
-    parser = argparse.ArgumentParser(
-        description="Update starcheck database")
+    parser = argparse.ArgumentParser(description="Update starcheck database")
     defaults = dict(DEFAULT_CONFIG)
     parser.set_defaults(**defaults)
-    parser.add_argument("--dbi",
-                        help="dbi for starcheck database")
-    parser.add_argument("--server",
-                        help="server or file for database")
-    parser.add_argument("--mp-top-level",
-                        help="top level SOT MP dir")
-    parser.add_argument("--start",
-                        help="update database with starcheck files after this start time")
+    parser.add_argument("--dbi", help="dbi for starcheck database")
+    parser.add_argument("--server", help="server or file for database")
+    parser.add_argument("--mp-top-level", help="top level SOT MP dir")
+    parser.add_argument(
+        "--start", help="update database with starcheck files after this start time"
+    )
     opt = parser.parse_args()
     return opt
 
@@ -113,73 +104,80 @@ def get_new_starcheck_files(rootdir, mtime=0):
     logger.info("Getting new starcheck.txt files from {}".format(rootdir))
     starchecks = []
     for root, dirs, files in os.walk(rootdir):
-        root = root.rstrip('/')
-        depth = len(root.split('/')) - 1
+        root = root.rstrip("/")
+        depth = len(root.split("/")) - 1
         if depth == 3:
-            prune_dirs(dirs, r'\d{4}$')
+            prune_dirs(dirs, r"\d{4}$")
         elif depth == 4:
-            prune_dirs(dirs, r'[A-Z]{3}\d{4}$')
+            prune_dirs(dirs, r"[A-Z]{3}\d{4}$")
         elif depth == 5:
-            prune_dirs(dirs, r'ofls[a-z]$')
+            prune_dirs(dirs, r"ofls[a-z]$")
         elif depth > 5:
-            files = [x for x in files if re.match(r'starcheck\.txt$', x)]
+            files = [x for x in files if re.match(r"starcheck\.txt$", x)]
             if len(files):
                 starchecks.append(os.path.join(root, files[0]))
             while dirs:
                 dirs.pop()
-    starchecks_with_times = [{'file': st, 'mtime': os.path.getmtime(st)}
-                             for st in starchecks if os.path.getmtime(st) >= mtime]
-    starchecks_with_times = sorted(starchecks_with_times, key=itemgetter('mtime'))
+    starchecks_with_times = [
+        {"file": st, "mtime": os.path.getmtime(st)}
+        for st in starchecks
+        if os.path.getmtime(st) >= mtime
+    ]
+    starchecks_with_times = sorted(starchecks_with_times, key=itemgetter("mtime"))
     return starchecks_with_times
 
 
 def update(config=None):
     if config is None:
         config = DEFAULT_CONFIG
-    if config['starcheck_db']['dbi'] != 'sqlite':
+    if config["starcheck_db"]["dbi"] != "sqlite":
         raise ValueError("Only sqlite DBI implemented")
     last_starcheck_mtime = 0
-    if (not os.path.exists(config['starcheck_db']['server'])
-            or os.stat(config['starcheck_db']['server']).st_size == 0):
-        if not os.path.exists(os.path.dirname(config['starcheck_db']['server'])):
-            os.makedirs(os.path.dirname(config['starcheck_db']['server']))
-        db_sql = Path(__file__).parent / FILES['sql_def']
+    if (
+        not os.path.exists(config["starcheck_db"]["server"])
+        or os.stat(config["starcheck_db"]["server"]).st_size == 0
+    ):
+        if not os.path.exists(os.path.dirname(config["starcheck_db"]["server"])):
+            os.makedirs(os.path.dirname(config["starcheck_db"]["server"]))
+        db_sql = Path(__file__).parent / FILES["sql_def"]
         db_init_cmds = open(db_sql).read()
-        db = Ska.DBI.DBI(dbi='sqlite', server=config['starcheck_db']['server'])
+        db = Ska.DBI.DBI(dbi="sqlite", server=config["starcheck_db"]["server"])
         db.execute(db_init_cmds)
     else:
-        db = Ska.DBI.DBI(dbi='sqlite', server=config['starcheck_db']['server'])
+        db = Ska.DBI.DBI(dbi="sqlite", server=config["starcheck_db"]["server"])
         max_mtime = db.fetchone("select max(mtime) as mtime from starcheck_id")
         if max_mtime is not None:
-            last_starcheck_mtime = max_mtime['mtime']
+            last_starcheck_mtime = max_mtime["mtime"]
     # If a start time is explicitly requested, override 0 or last database value
-    if 'start' in config and config['start'] is not None:
-        last_starcheck_mtime = DateTime(config['start']).unix
-    starchecks_with_times = get_new_starcheck_files(config['mp_top_level'],
-                                                    mtime=last_starcheck_mtime)
+    if "start" in config and config["start"] is not None:
+        last_starcheck_mtime = DateTime(config["start"]).unix
+    starchecks_with_times = get_new_starcheck_files(
+        config["mp_top_level"], mtime=last_starcheck_mtime
+    )
 
     for st_with_time in starchecks_with_times:
-        st = st_with_time['file']
+        st = st_with_time["file"]
         logger.info("Attempting ingest of %s" % st)
         # get an existing id or insert a new one
         mp_dir = re.search(
-            '\/data\/mpcrit1\/mplogs(\/\d{4}\/\w{7}/\w{5}\/)starcheck.txt',
-            st).group(1)
-        idcheck = db.fetchone(
-            "select id from starcheck_id where dir = '%s'" % mp_dir)
+            "\/data\/mpcrit1\/mplogs(\/\d{4}\/\w{7}/\w{5}\/)starcheck.txt", st
+        ).group(1)
+        idcheck = db.fetchone("select id from starcheck_id where dir = '%s'" % mp_dir)
         existing = None
         if idcheck is not None:
-            sc_id = idcheck['id']
+            sc_id = idcheck["id"]
             existing = db.fetchall(
-                "select * from starcheck_obs where sc_id = '%d'" % sc_id)
+                "select * from starcheck_obs where sc_id = '%d'" % sc_id
+            )
         else:
-            sc_id = db.fetchone(
-                "select max(id) + 1 as id from starcheck_id")['id'] or 0
-            db.insert(dict(id=sc_id, dir=mp_dir, mtime=st_with_time['mtime']), 'starcheck_id')
+            sc_id = db.fetchone("select max(id) + 1 as id from starcheck_id")["id"] or 0
+            db.insert(
+                dict(id=sc_id, dir=mp_dir, mtime=st_with_time["mtime"]), "starcheck_id"
+            )
             db.commit()
 
         starcheck = read_starcheck(st)
-        for (obs, obs_idx) in zip(starcheck, count(0)):
+        for obs, obs_idx in zip(starcheck, count(0)):
             ingest_obs(obs, obs_idx, sc_id, st, db, existing=existing)
 
 
@@ -191,5 +189,6 @@ def main():
     opt = get_options()
     update(config=vars(opt))
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/mica/starcheck/tests/make_database.py
+++ b/mica/starcheck/tests/make_database.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
 import shutil
 import tempfile
+
 from Chandra.Time import DateTime
+
 import mica.common
 
 # Override MICA_ARCHIVE with a temporary directory
@@ -14,7 +15,7 @@ import mica.starcheck.process
 # Just ingest files from the last couple of weeks or so
 # And just check (implicitly) that the update script didn't raise any exceptions
 config = mica.starcheck.process.DEFAULT_CONFIG
-config['start'] = DateTime() - 30
+config["start"] = DateTime() - 30
 mica.starcheck.process.update(config)
 # Cleanup manually
 shutil.rmtree(TESTDIR)


### PR DESCRIPTION
## Description

This tidies up the `mica.starcheck` subpackage in advance of removing the `timelines` database dependence.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac

Independent check of unit tests by Jean
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
The only non-automated check was fixing the regex expression in 26d18a4c108265998ead30b7a8827e86e73d90c0. (The forward slash `/` is not a special character and should not be escaped). I tested this with:
```
In [4]: st = '/data/mpcrit1/mplogs/2020/APR2020/oflsa/starcheck.txt'

In [5]:         mp_dir = re.search(
   ...:             r"/data/mpcrit1/mplogs(/\d{4}/\w{7}/\w{5}/)starcheck.txt", st
   ...:         ).group(1)
   ...: 

In [6]: mp_dir
Out[6]: '/2020/APR2020/oflsa/'
```
