### PR TITLE
Remove timelines / cmd_states.db3 from mica

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -116,7 +116,7 @@ Functions
 Functions
 ---------
 
-.. autofunction:: get_timeline_at_date
+.. autofunction:: load_name_to_mp_dir
 
 
 :mod:`mica.starcheck`

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -611,7 +611,7 @@ def main(obsid):
     if er:
         stat_map = {'ran': 'ran on',
                     'approved': 'approved for',
-                    'ran_pretimelines': 'ran on',
+                    'ran_pre_commands': 'ran on',
                     'planned': 'planned for'}
         er_status = "{} {}".format(stat_map[status], obs_sc['obs']['mp_starcat_time'])
         run_obspar = None

--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -22,10 +22,6 @@ DEFAULT_CONFIG = dict(
         dbi="sqlite", server=os.path.join(MICA_ARCHIVE, "starcheck", "starcheck.db3")
     ),
     mp_top_level="/data/mpcrit1/mplogs",
-    timelines_db=dict(
-        dbi="sqlite",
-        server=os.path.join(os.environ["SKA"], "data", "cmd_states", "cmd_states.db3"),
-    ),
 )
 FILES = dict(data_root=os.path.join(MICA_ARCHIVE, "starcheck"), sql_def="starcheck.sql")
 

--- a/mica/starcheck/starcheck.py
+++ b/mica/starcheck/starcheck.py
@@ -198,6 +198,10 @@ def get_starcheck_catalog_at_date(date, starcheck_db=None):
         # This should never happen.
         raise ValueError(f"could not find observation at {date}")
 
+    if obs["source"] == "CMD_EVT":
+        # This follows the API where if there is no starcheck entry then return None
+        return None
+
     mp_dir = load_name_to_mp_dir(obs["source"])
 
     # Kadi observations are labeled by the commanded obsid.  Starcheck catalogs

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -154,14 +154,14 @@ def test_obsid_catalog_fetch():
         {"obsid": 17210, "mp_dir": "/2016/JAN2516/oflsa/", "n_cat_entries": 11},
         {"obsid": 62668},
     ]
-    # 62668 should be an undercover with no catalog
+    # 45312 is a gyro hold with no star catalog
     for t in tests:
         sc = starcheck.get_starcheck_catalog(t["obsid"])
         if "mp_dir" in t:
             assert t["mp_dir"] == sc["mp_dir"]
         if "n_cat_entries" in t:
             assert len(sc["cat"]) == t["n_cat_entries"]
-        if t["obsid"] == 62668:
+        if t["obsid"] == 45312:
             assert sc is None
     # review a dark current replica obsid
     dcdir, dcstatus, dcdate = starcheck.get_mp_dir(49961)
@@ -188,7 +188,7 @@ def test_get_starcheck_methods():
     starcheck.OBS_CACHE.clear()
 
     # Get the catalog for any obsid to add something to the cache
-    starcheck.get_starcat(2121)
+    starcheck.get_starcat(8008)
     assert len(starcheck.OBS_CACHE) == 1
 
     # Get an check the values for the utility methods for obsid 19372
@@ -226,7 +226,8 @@ def test_get_starcheck_methods():
     att = starcheck.get_att(obsid)
     assert att == [209.04218, 47.227524, 357.020117]
 
-    obsid = 2000
+    # Check a full-sequence dark cal obs from SEP3019A
+    obsid = 47846
     dither = starcheck.get_dither(obsid)
     assert dither == {
         "pitch_ampl": 0.0,

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -149,13 +149,14 @@ def test_validate_catalogs_over_range():
 
 
 @pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
-@pytest.mark.parametrize("test_case",
+@pytest.mark.parametrize(
+    "test_case",
     [
         {"obsid": 19990, "mp_dir": "/2017/FEB2017/oflsa/", "n_cat_entries": 11},
         {"obsid": 17210, "mp_dir": "/2016/JAN2516/oflsa/", "n_cat_entries": 11},
         # 45312 is a gyro hold with no star catalog
         {"obsid": 45312, "mp_dir": "/2022/AUG2322/oflsa/", "n_cat_entries": 0},
-    ]
+    ],
 )
 def test_obsid_catalog_fetch(test_case):
     sc = starcheck.get_starcheck_catalog(test_case["obsid"])
@@ -243,8 +244,27 @@ def test_get_starcheck_methods():
 def test_get_starcheck_vs_kadi():
     # Make sure this works for an obsid in kadi commands
     cat_mica = starcheck.get_starcat(8008)
-    cat_kadi = kadi_get_starcats(obsid=8008, scenario='flight')[0]
-    assert np.all(cat_mica['id'] == cat_kadi['id'])
+    cat_kadi = kadi_get_starcats(obsid=8008, scenario="flight")[0]
+    assert np.all(cat_mica["id"] == cat_kadi["id"])
+
+
+@pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
+def test_get_starcheck_db_obsid():
+    obsid = starcheck.get_starcheck_db_obsid(
+        "2022:017:05:15:06.000", mp_dir="/2022/JAN1722/oflsa/"
+    )
+    assert obsid == 45774
+
+
+@pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
+def test_get_starcheck_scs107():
+    cat = starcheck.get_starcheck_catalog_at_date("2022:017:06:00:00.000")
+    assert cat["obs"]["obsid"] == 45774
+    cat_mica = cat['cat']
+    cat_kadi = kadi_get_starcats(
+        obsid=26269, starcat_date="2022:017:05:15:06.000", scenario="flight"
+    )[0]
+    assert np.all(cat_mica["id"] == cat_kadi["id"])
 
 
 @pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -255,6 +255,22 @@ def test_get_starcheck_db_obsid():
     )
     assert obsid == 45774
 
+    # Science observation not run due to SCS-107. The as-run obsid is 45091 (obsid at
+    # the time of the interrupt) but the planned obsid in the starcheck database is
+    # 26269. The case above may be similar but didn't get documented.
+    obsid = starcheck.get_starcheck_db_obsid(
+        "2022:311:02:39:03.454", "/2022/NOV0722/oflsa/"
+    )
+    assert obsid == 25316
+
+
+@pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
+def test_get_starcheck_db_obsid_fail():
+    with pytest.raises(ValueError, match="no starcheck entry"):
+        starcheck.get_starcheck_db_obsid(
+            "2022:017:05:15:06.000", mp_dir="/2022/JAN1722/oflsZZZ/"
+        )
+
 
 @pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
 def test_get_starcheck_scs107():

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -149,21 +149,22 @@ def test_validate_catalogs_over_range():
 
 
 @pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
-def test_obsid_catalog_fetch():
-    tests = [
+@pytest.mark.parametrize("test_case",
+    [
         {"obsid": 19990, "mp_dir": "/2017/FEB2017/oflsa/", "n_cat_entries": 11},
         {"obsid": 17210, "mp_dir": "/2016/JAN2516/oflsa/", "n_cat_entries": 11},
-        {"obsid": 62668},
+        # 45312 is a gyro hold with no star catalog
+        {"obsid": 45312, "mp_dir": "/2022/AUG2322/oflsa/", "n_cat_entries": 0},
     ]
-    # 45312 is a gyro hold with no star catalog
-    for t in tests:
-        sc = starcheck.get_starcheck_catalog(t["obsid"])
-        if "mp_dir" in t:
-            assert t["mp_dir"] == sc["mp_dir"]
-        if "n_cat_entries" in t:
-            assert len(sc["cat"]) == t["n_cat_entries"]
-        if t["obsid"] == 45312:
-            assert sc is None
+)
+def test_obsid_catalog_fetch(test_case):
+    sc = starcheck.get_starcheck_catalog(test_case["obsid"])
+    assert test_case["mp_dir"] == sc["mp_dir"]
+    assert len(sc["cat"]) == test_case["n_cat_entries"]
+
+
+@pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
+def test_obsid_catalog_fetch_dark_cal():
     # review a dark current replica obsid
     dcdir, dcstatus, dcdate = starcheck.get_mp_dir(49961)
     assert dcdir == "/2017/JUL0317/oflsb/"

--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -297,3 +297,46 @@ def test_get_starcheck_with_mp_dir():
     sc = starcheck.get_starcheck_catalog(21082, "APR2318A")
     assert len(sc["cat"]) == 12
     assert (21082, "APR2318A") in starcheck.OBS_CACHE
+
+
+@pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
+def test_get_starcheck_for_no_star_catalog():
+    """Test getting starcheck by date for a time that has no star catalog (gyro hold)"""
+    cat = starcheck.get_starcheck_catalog_at_date('2023:099:04:21:40.719')
+    exp = exp = {
+        "mp_dir": "/2023/APR0323/oflsa/",
+        "status": "ran",
+        "obs": {
+            "sc_id": 2477,
+            "obsid": 44653,
+            "obs_idx": 45,
+            "point_ra": 304.0,
+            "point_dec": -52.0,
+            "point_roll": 107.709085,
+            "target_id": None,
+            "sci_instr": None,
+            "sim_z_offset_steps": None,
+            "sim_z_offset_mm": None,
+            "grating": None,
+            "dither_state": None,
+            "dither_y_amp": None,
+            "dither_y_period": None,
+            "dither_z_amp": None,
+            "dither_z_period": None,
+            "mp_starcat_time": None,
+            "mp_starcat_vcdu_cnt": None,
+            "obsid_as_run": 44653,
+        },
+        "manvr": [],
+        "warnings": [],
+        "cat": [],
+    }
+    assert cat == exp
+
+
+@pytest.mark.skipif("not HAS_SC_ARCHIVE", reason="Test requires starcheck archive")
+def test_get_starcheck_for_no_starcheck_entry():
+    """Test getting starcheck by date after a while in safe mode with no loads"""
+    date = "2023:050:00:30:00"
+    cat = starcheck.get_starcheck_catalog_at_date(date)
+    assert cat is None

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -520,9 +520,9 @@ def calc_stats(obsid):
     guide_start = manvr.guide_start
     try:
         starcheck = get_starcheck_catalog_at_date(manvr.acq_start)
-    except:
-        # bad timelines for these observations, skip the tstart
-        # input for get_starcheck_catalog
+    except Exception:
+        # No matching observations for some known observations with problems. Use
+        # hard-coded input for get_starcheck_catalog.
         if obsid in [1966]:
             starcheck = get_starcheck_catalog(obsid,
                                               mp_dir='/2002/JAN1202/oflsa')

--- a/mica/utils.py
+++ b/mica/utils.py
@@ -1,9 +1,7 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
 
-from Chandra.Time import DateTime
 from kadi.commands.core import ska_load_dir
-import Ska.DBI
 
 DEFAULT_CONFIG = dict(
     timelines_db=dict(
@@ -11,25 +9,6 @@ DEFAULT_CONFIG = dict(
         server=os.path.join(os.environ["SKA"], "data", "cmd_states", "cmd_states.db3"),
     )
 )
-
-
-def get_timeline_at_date(date, timelines_db=None):
-    """
-    Return timeline that contains a given date.  The 'timeline_loads' query is used
-    to give the mp_dir as well as datestart and datestop for the timeline.
-
-    :param date: Chandra.Time compatible date
-    :param timelines_db: optional already-open handle to cmd_states/timelines database.
-    :returns: dictionary of appropriate record from timeline_loads table
-    """
-
-    date = DateTime(date).date
-    if timelines_db is None:
-        timelines_db = Ska.DBI.DBI(**DEFAULT_CONFIG["timelines_db"])
-    return timelines_db.fetchone(
-        "select * from timeline_loads where datestop >= '%s' "
-        " and datestart <= '%s' and scs <= 130 order by datestart desc" % (date, date)
-    )
 
 
 def load_name_to_mp_dir(load_name):

--- a/mica/utils.py
+++ b/mica/utils.py
@@ -3,12 +3,7 @@ import os
 
 from kadi.commands.core import ska_load_dir
 
-DEFAULT_CONFIG = dict(
-    timelines_db=dict(
-        dbi="sqlite",
-        server=os.path.join(os.environ["SKA"], "data", "cmd_states", "cmd_states.db3"),
-    )
-)
+DEFAULT_CONFIG = {}
 
 
 def load_name_to_mp_dir(load_name):

--- a/mica/utils.py
+++ b/mica/utils.py
@@ -1,11 +1,16 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 import os
+
 from Chandra.Time import DateTime
+from kadi.commands.core import ska_load_dir
 import Ska.DBI
 
-DEFAULT_CONFIG = dict(timelines_db=dict(
-        dbi='sqlite',
-        server=os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')))
+DEFAULT_CONFIG = dict(
+    timelines_db=dict(
+        dbi="sqlite",
+        server=os.path.join(os.environ["SKA"], "data", "cmd_states", "cmd_states.db3"),
+    )
+)
 
 
 def get_timeline_at_date(date, timelines_db=None):
@@ -14,14 +19,26 @@ def get_timeline_at_date(date, timelines_db=None):
     to give the mp_dir as well as datestart and datestop for the timeline.
 
     :param date: Chandra.Time compatible date
-    :param timelines_db: optional already-open handle to a cmd_states/timelines database.
+    :param timelines_db: optional already-open handle to cmd_states/timelines database.
     :returns: dictionary of appropriate record from timeline_loads table
     """
 
     date = DateTime(date).date
     if timelines_db is None:
-        timelines_db = Ska.DBI.DBI(**DEFAULT_CONFIG['timelines_db'])
+        timelines_db = Ska.DBI.DBI(**DEFAULT_CONFIG["timelines_db"])
     return timelines_db.fetchone(
         "select * from timeline_loads where datestop >= '%s' "
-        " and datestart <= '%s' and scs <= 130 order by datestart desc"
-        % (date, date))
+        " and datestart <= '%s' and scs <= 130 order by datestart desc" % (date, date)
+    )
+
+
+def load_name_to_mp_dir(load_name):
+    """Convert ``load_name`` like DEC2506C to /2006/DEC2506/oflsc/.
+
+    :param load_name: str load name
+    :returns: str mica-format mission planning dir
+    """
+    # Get the last 3 parts of the full load directory path YEAR/LOAD/ofls{REV}
+    dir_parts = ska_load_dir(load_name).parts
+    out = "/" + "/".join(dir_parts[-3:]) + "/"
+    return out

--- a/mica/web/pcad_table.py
+++ b/mica/web/pcad_table.py
@@ -90,9 +90,7 @@ def get_acq_table(obsid):
     # Get the catalog for the stars
     # This is used both to map ACQID to the right slot and
     # to get the star positions to estimate deltas later
-    timeline_at_acq = mica.starcheck.starcheck.get_timeline_at_date(manvr.start)
-    mp_dir = None if (timeline_at_acq is None) else timeline_at_acq['mp_dir']
-    starcheck = mica.starcheck.get_starcheck_catalog(int(obsid), mp_dir=mp_dir)
+    starcheck = mica.starcheck.get_starcheck_catalog_at_date(manvr.start)
     if 'cat' not in starcheck:
         raise ValueError('No starcheck catalog found for {}'.format(obsid))
     catalog = Table(starcheck['cat'])

--- a/overview.rst
+++ b/overview.rst
@@ -26,13 +26,11 @@ Data Sources
 Planning data
 --------------
 
-Starcheck outputs.  
-  The starcheck outputs are already stored in sybase tables (starcheck_catalog,
-  starcheck_manvr, starcheck_obs, starcheck_warnings).  The timelines table
-  also maps the obsid to its SOT MP directory to get a link to the original
-  products (including the plots).
+Starcheck outputs.
+  The starcheck outputs are already stored in database tables (starcheck_catalog,
+  starcheck_manvr, starcheck_obs, starcheck_warnings).
 
-Maneuver sequence data  
+Maneuver sequence data
   The maneuvers to and from the obsid target
   should be presented in context.  The ms*sum file in the planned products
   directory should be parsed for these data.  A new tool should archive

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-    ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
-


### PR DESCRIPTION
## Description

This removes the `cmd_states.db3` (and `timelines`) dependence from mica.

I'm not sure if any of these changes impact or break processing that is not covered in unit tests. This definitely needs close review by @jeanconn.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
- It's possible that some old (pre-2003) queries may give different results.
- The `status` fields have been reduced/simplified and might give different results from the previous version.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
- [x] Linux (kady)

Independent check of unit tests by Jean
- [X] Linux (fido)

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
None but many new unit tests.