### PR TITLE
Update CDA code and tests for DS10.12

### DIFF
--- a/mica/archive/cda/services.py
+++ b/mica/archive/cda/services.py
@@ -284,21 +284,21 @@ def _update_params_from_kwargs(params, obsid,
         params['obsid'] = obsid
 
     if ra is not None:
-        params['ra'] = ra
+        params['lon'] = ra
     if dec is not None:
-        params['dec'] = dec
+        params['lat'] = dec
 
     if target_name is not None:
         if resolve_name:
             coord = SkyCoord.from_name(target_name)
-            params['ra'] = coord.ra.deg
-            params['dec'] = coord.dec.deg
+            params['lon'] = coord.ra.deg
+            params['lat'] = coord.dec.deg
         else:
             # SR services API uses "target" to select substrings of target_name
             params['target'] = target_name
 
     # For any positional search include the radius
-    if 'ra' in params and 'dec' in params:
+    if 'lon' in params and 'lat' in params:
         params['radius'] = radius
 
     return params

--- a/mica/archive/tests/test_cda.py
+++ b/mica/archive/tests/test_cda.py
@@ -45,7 +45,6 @@ COLNAMES = {
 
 # Ensure tests continue to work in future by always using a fixed date range
 DATE_RANGE = '1999-01-01/2021-11-01'
-
 get_ocat_web = partial(get_ocat_web, startDate=DATE_RANGE)
 
 

--- a/mica/archive/tests/test_cda.py
+++ b/mica/archive/tests/test_cda.py
@@ -22,7 +22,7 @@ COLNAMES = {
     'detail': [
         'seq_num', 'status', 'obsid', 'pr_num', 'target_name', 'grid_name', 'instr', 'grat', 'type',
         'obs_cycle', 'prop_cycle', 'charge_cycle', 'start_date', 'public_avail', 'readout_detector',
-        'datamode', 'joint', 'hst', 'noao', 'nrao', 'rxte', 'spitzer', 'suzaku', 'xmm', 'swift',
+        'datamode', 'joint', 'hst', 'jwst', 'noao', 'nrao', 'rxte', 'spitzer', 'suzaku', 'xmm', 'swift',
         'nustar', 'category', 'seg_max_num', 'prop_title', 'pi_name', 'observer', 'app_exp',
         'exp_time', 'ra', 'dec', 'soe_roll', 'time_crit', 'y_off', 'z_off', 'x_sim', 'z_sim',
         'raster', 'obj_type', 'obj', 'photo', 'vmag', 'est_cnt_rate', 'forder_cnt_rate',
@@ -45,6 +45,7 @@ COLNAMES = {
 
 # Ensure tests continue to work in future by always using a fixed date range
 DATE_RANGE = '1999-01-01/2021-11-01'
+
 get_ocat_web = partial(get_ocat_web, startDate=DATE_RANGE)
 
 


### PR DESCRIPTION
## Description
Update CDA code and tests for DS10.12

It looks like 'ra' and 'dec' no longer work as aliases for 'lon' and 'lat' in the web services.  'jwst' looks to now be an output column.


## Interface impacts
'jwst' became a column in the ocat local data with DS10.12 but is not an interface impact of this PR.
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac


Independent check of unit tests by Javier
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
