### PR TITLE
Set mica agasc calls to use miniagasc*

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -446,7 +446,7 @@ def catalog_info(starcheck_cat, acqs=None, trak=None, vv=None):
 
 def get_star(id):
     try:
-        agasc_info = agasc.get_star(id, agasc_file=agasc.get_agasc_filename('miniagasc_*'))
+        agasc_info = agasc.get_star(id, agasc_file='miniagasc_*')
         agasc_list = [(key, agasc_info[key]) for key in agasc_info.dtype.names]
         return agasc_list
     except:

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -446,7 +446,7 @@ def catalog_info(starcheck_cat, acqs=None, trak=None, vv=None):
 
 def get_star(id):
     try:
-        agasc_info = agasc.get_star(id)
+        agasc_info = agasc.get_star(id, agasc_file=agasc.get_agasc_filename('miniagasc_*'))
         agasc_list = [(key, agasc_info[key]) for key in agasc_info.dtype.names]
         return agasc_list
     except:

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -149,7 +149,7 @@ def _deltas_vs_obc_quat(vals, times, catalog):
             continue
         try:
             star = agasc.get_star(agasc_id, date=times[0],
-                                  agasc_file=agasc.get_agasc_filename('miniagasc_*'),
+                                  agasc_file='miniagasc_*',
                                   use_supplement=False)
         except:
             logger.info("agasc error on slot {}:{}".format(

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -148,7 +148,9 @@ def _deltas_vs_obc_quat(vals, times, catalog):
             logger.info("No agasc id for slot {}, skipping".format(slot))
             continue
         try:
-            star = agasc.get_star(agasc_id, date=times[0], use_supplement=False)
+            star = agasc.get_star(agasc_id, date=times[0],
+                                  agasc_file=agasc.get_agasc_filename('miniagasc_*'),
+                                  use_supplement=False)
         except:
             logger.info("agasc error on slot {}:{}".format(
                     slot, sys.exc_info()[0]))

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -180,7 +180,7 @@ def _deltas_vs_obc_quat(vals, times, catalog):
         try:
             # This is not perfect for star catalogs for agasc 1.4 and 1.5
             star = agasc.get_star(agasc_id, date=times[0],
-                                  agasc_file=agasc.get_agasc_filename('miniagasc_*'),
+                                  agasc_file='miniagasc_*',
                                   use_supplement=False)
         except:
             logger.info("agasc error on slot {}:{}".format(

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -179,7 +179,9 @@ def _deltas_vs_obc_quat(vals, times, catalog):
             continue
         try:
             # This is not perfect for star catalogs for agasc 1.4 and 1.5
-            star = agasc.get_star(agasc_id, date=times[0], use_supplement=False)
+            star = agasc.get_star(agasc_id, date=times[0],
+                                  agasc_file=agasc.get_agasc_filename('miniagasc_*'),
+                                  use_supplement=False)
         except:
             logger.info("agasc error on slot {}:{}".format(
                     slot, sys.exc_info()[0]))

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -1035,7 +1035,8 @@ class AspectInterval(object):
 
             if ocat_info['type'] == 1:
                 import agasc
-                star_info = agasc.get_star(ocat_info['id'], use_supplement=False)
+                star_info = agasc.get_star(ocat_info['id'], use_supplement=False,
+                                           agasc_file=agasc.get_agasc_filename('miniagasc_*'))
                 mock_prop = dict(cel_loc_flag=0,
                                  id_status='OMITTED',
                                  agasc_id=ocat_info['id'],

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -1036,7 +1036,7 @@ class AspectInterval(object):
             if ocat_info['type'] == 1:
                 import agasc
                 star_info = agasc.get_star(ocat_info['id'], use_supplement=False,
-                                           agasc_file=agasc.get_agasc_filename('miniagasc_*'))
+                                           agasc_file='miniagasc_*')
                 mock_prop = dict(cel_loc_flag=0,
                                  id_status='OMITTED',
                                  agasc_id=ocat_info['id'],

--- a/mica/web/views.py
+++ b/mica/web/views.py
@@ -62,7 +62,7 @@ class StarHistView(BaseView, TemplateView):
             import agasc
             from agasc.agasc import IdNotFound
             try:
-                agasc_info = agasc.get_star(agasc_id)
+                agasc_info = agasc.get_star(agasc_id, agasc_file=agasc.get_agasc_filename('miniagasc_*'))
                 context['star_info'] = [(key, agasc_info[key]) for key in agasc_info.dtype.names]
             except IdNotFound:
                 context['star_info'] = []

--- a/mica/web/views.py
+++ b/mica/web/views.py
@@ -62,7 +62,7 @@ class StarHistView(BaseView, TemplateView):
             import agasc
             from agasc.agasc import IdNotFound
             try:
-                agasc_info = agasc.get_star(agasc_id, agasc_file=agasc.get_agasc_filename('miniagasc_*'))
+                agasc_info = agasc.get_star(agasc_id, agasc_file='miniagasc_*')
                 context['star_info'] = [(key, agasc_info[key]) for key in agasc_info.dtype.names]
             except IdNotFound:
                 context['star_info'] = []


### PR DESCRIPTION
## Description

Set mica agasc calls to use miniagasc*

This is in response to https://github.com/sot/agasc/pull/155 which changes the default agasc file to the most recent proseco agasc.  Overall that makes sense for operations, but bits of the mica code expect columns that aren't present in the proseco agasc.  It would probably be useful to update mica to just not use those columns (even for display) but for now I think it makes sense to update the calls in mica to use the miniagasc.  And this may end up being somewhat application specific in mica so I didn't set up any configuration for it.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
mica tests don't pass with https://github.com/sot/agasc/pull/155 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested against a ska3-masters environment with https://github.com/sot/agasc/pull/155 .

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
