### PR TITLE
Handle no-starcat observations better in reports

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -337,19 +337,20 @@ def obs_links(obsid, sequence=None, plan=None):
         dir_match = re.match(r'/\d{4}/(\w{3}\d{4})/ofls(\w)', mp_dir)
         mp_label = "{}{}".format(dir_match.group(1),
                                  dir_match.group(2).upper())
-        mp_date_m = re.match(r'(\d{4}):(\d{3}):\d{2}:\d{2}:\d{2}\.\d{3}', mp_date)
-        if mp_date_m:
-            year = int(mp_date_m.group(1))
-            doy = int(mp_date_m.group(2))
+        if mp_date is not None:
+            mp_date_m = re.match(r'(\d{4}):(\d{3}):\d{2}:\d{2}:\d{2}\.\d{3}', mp_date)
+            if mp_date_m:
+                year = int(mp_date_m.group(1))
+                doy = int(mp_date_m.group(2))
 
-            dtm = datetime.datetime(year, 1, 1) + datetime.timedelta(doy - 1)
-            month = dtm.strftime("%b")
-            dom = dtm.strftime("%d")
-            links['fot_daily'] = {
-                'label': "Daily Plots {}:{:03d}".format(year, int(doy)),
-                'link': "{root}/{year}/{upper_month}/{lower_month}{day_of_month:02d}_{doy:03d}/".format(
-                    root=DAILY_PLOT_ROOT, year=year, upper_month=month.upper(),
-                    lower_month=month.lower(), day_of_month=int(dom), doy=int(doy))}
+                dtm = datetime.datetime(year, 1, 1) + datetime.timedelta(doy - 1)
+                month = dtm.strftime("%b")
+                dom = dtm.strftime("%d")
+                links['fot_daily'] = {
+                    'label': "Daily Plots {}:{:03d}".format(year, int(doy)),
+                    'link': "{root}/{year}/{upper_month}/{lower_month}{day_of_month:02d}_{doy:03d}/".format(
+                        root=DAILY_PLOT_ROOT, year=year, upper_month=month.upper(),
+                        lower_month=month.lower(), day_of_month=int(dom), doy=int(doy))}
         vv, vvid = official_vv(obsid)
         links['shortterm'] = {'link': guess_shortterm(mp_dir),
                               'label': "Short Term Sched. {}".format(mp_label)}

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -540,6 +540,8 @@ def main(obsid):
             if plan_date.cxcsec > (CxoTime.now() + 21 * u.day).secs:
                 raise LookupError("No starcheck expected for {} lts date".format(str(plan)))
         mp_dir, status, mp_date = starcheck.get_mp_dir(obsid)
+        if status == 'no starcat':
+            raise LookupError("No starcat")
         obs_sc, mp_dir, status = get_starcheck(obsid)
         logger.debug("Plotting starcheck catalog to {}".format(os.path.join(outdir, 'starcheck.png')))
         if obs_sc['obs']['point_ra'] is None:
@@ -551,7 +553,7 @@ def main(obsid):
         fig.savefig(os.path.join(outdir, 'starcheck.png'))
         plt.close('all')
     except LookupError as detail:
-        logger.info("No starcheck catalog.  Writing out OCAT info only")
+        logger.info("No starcheck catalog or no starcat.  Writing out OCAT info only")
         logger.info(detail)
         template = jinja_env.get_template('report.html')
         page = template.render(obsid=obsid,

--- a/mica/report/tests/test_write_report.py
+++ b/mica/report/tests/test_write_report.py
@@ -43,7 +43,7 @@ def test_write_reports():
     os.unlink(fn)
     report.REPORT_ROOT = tempdir
     report.REPORT_SERVER = fn
-    for obsid in [20001, 15175, 54778]:
+    for obsid in [20001, 15175, 54778, 44077]:
         report.main(obsid)
     os.unlink(fn)
     shutil.rmtree(tempdir)


### PR DESCRIPTION
## Description

Tiny changes to handle no starcat observations better in reports.  For observations that do not have star catalogs (NMM dwells for IR zone especially) handle the missing star catalog with a handled exception instead of an error and don't try to parse the missing date.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Should stop the "Failed report on 44077" type errors.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested against a linux ska3-masters environment

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux -

Independent check of unit tests by Javier
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Updated the report writing unit test to include a recent ER that has no star catalog.  With this PR that passes -- fails against master.
