### PR TITLE
Use parse_cm load_dir_from_load_name and test

### DIFF
--- a/mica/starcheck/tests/test_catalog_fetches.py
+++ b/mica/starcheck/tests/test_catalog_fetches.py
@@ -11,6 +11,7 @@ from Ska.engarchive import fetch
 from Ska.quatutil import radec2yagzag, yagzag2radec
 
 from .. import starcheck
+from mica.utils import load_name_to_mp_dir
 
 HAS_SC_ARCHIVE = os.path.exists(starcheck.FILES["data_root"])
 
@@ -340,3 +341,8 @@ def test_get_starcheck_for_no_starcheck_entry():
     date = "2023:050:00:30:00"
     cat = starcheck.get_starcheck_catalog_at_date(date)
     assert cat is None
+
+
+def test_load_name_to_mp_dir():
+    mp_dir = load_name_to_mp_dir("DEC2506C")
+    assert mp_dir == "/2006/DEC2506/oflsc/"

--- a/mica/utils.py
+++ b/mica/utils.py
@@ -1,7 +1,5 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
-import os
-
-from kadi.commands.core import ska_load_dir
+from parse_cm.paths import load_dir_from_load_name
 
 DEFAULT_CONFIG = {}
 
@@ -13,6 +11,6 @@ def load_name_to_mp_dir(load_name):
     :returns: str mica-format mission planning dir
     """
     # Get the last 3 parts of the full load directory path YEAR/LOAD/ofls{REV}
-    dir_parts = ska_load_dir(load_name).parts
+    dir_parts = load_dir_from_load_name(load_name).parts
     out = "/" + "/".join(dir_parts[-3:]) + "/"
     return out


### PR DESCRIPTION
## Description

This updates a utiliity function to use `parse_cm.paths.load_dir_from_load_name()` instead of `kadi.commands.core.ska_load_dir()` which is deprecated.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac (with new unit test)
This was done in an environment with https://github.com/sot/kadi/pull/310 installed.
```
(masters) ➜  mica git:(use-parsecm-load-dir-from-load-name) git rev-parse HEAD                                                             
892751a4701f92c08daa6278a0f30ea75ddcd34a
(masters) ➜  mica git:(use-parsecm-load-dir-from-load-name) pytest                      
==================================================================== test session starts ====================================================================
platform darwin -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /Users/aldcroft/git, configfile: pytest.ini
plugins: timeout-2.1.0, anyio-3.6.2
collected 107 items                                                                                                                                         

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                            [ 16%]
mica/archive/tests/test_aca_hdr3.py s                                                                                                                 [ 17%]
mica/archive/tests/test_aca_l0.py sss                                                                                                                 [ 20%]
mica/archive/tests/test_asp_l1.py ssssss                                                                                                              [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                         [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                   [ 70%]
mica/report/tests/test_write_report.py s                                                                                                              [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                          [ 85%]
mica/stats/tests/test_acq_stats.py .ss                                                                                                                [ 87%]
mica/stats/tests/test_guide_stats.py .sss                                                                                                             [ 91%]
mica/vv/tests/test_vv.py sssssssss                                                                                                                    [100%]

============================================================== 82 passed, 25 skipped in 20.63s ==============================================================
(razl) ➜  mica git:(use-parsecm-load-dir-from-load-name)  
```

Independent check of unit tests by Jean
- [x] Linux

```
(ska3-masters) jeanconn-fido> pytest
===================================================================================== test session starts =====================================================================================
platform linux -- Python 3.10.8, pytest-7.2.1, pluggy-1.0.0
rootdir: /proj/sot/ska/jeanproj/git/mica
plugins: timeout-2.1.0, anyio-3.6.2
collected 107 items                                                                                                                                                                           

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                              [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                                   [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                                                                   [ 20%]
mica/archive/tests/test_asp_l1.py ......                                                                                                                                                [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                                                           [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                                                     [ 70%]
mica/report/tests/test_write_report.py .                                                                                                                                                [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                                            [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                                  [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                               [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                                                      [100%]

====================================================================================== warnings summary =======================================================================================
../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21
../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21
  /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/numexpr/expressions.py:21: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
    _np_version_forbids_neg_powint = LooseVersion(numpy.__version__) >= LooseVersion('1.12.0b1')

../../../../../../fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/jupyter_client/connect.py:27
  /fido.real/conda/envs/ska3-masters/lib/python3.10/site-packages/jupyter_client/connect.py:27: DeprecationWarning: Jupyter is migrating its paths to use standard platformdirs
  given by the platformdirs library.  To remove this warning and
  see the appropriate new directories, set the environment variable
  `JUPYTER_PLATFORM_DIRS=1` and then run `jupyter --paths`.
  The use of platformdirs will be the default in `jupyter_core` v6
    from jupyter_core.paths import jupyter_data_dir

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================================= 107 passed, 3 warnings in 527.59s (0:08:47) ===============================================================
(ska3-masters) jeanconn-fido> python -c "import kadi; print(kadi.__version__)"
7.8.1.dev13+g2b977de
(ska3-masters) jeanconn-fido> git rev-parse HEAD
8a8995e1197fc101a83dc75871ab5ab1c21807f1
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
For kicks I modified the `load_name_to_mp_dir()` function always return `""` to check test coverage. This failed a number of tests in `test_catalog_fetches.py` so that is reassuring.
