### PR TITLE
Set acq stats processing to continue on individual obsid exceptions

### DIFF
--- a/mica/stats/tests/test_acq_stats.py
+++ b/mica/stats/tests/test_acq_stats.py
@@ -25,6 +25,14 @@ def test_calc_stats():
     acq_stats.calc_stats(4911)
     acq_stats.calc_stats(19386)
 
+    # This one raises a ValueError
+    with pytest.raises(ValueError):
+        acq_stats.calc_stats(29211)
+
+    # This one raises an IndexError
+    with pytest.raises(IndexError):
+        acq_stats.calc_stats(62620)
+
 
 @pytest.mark.skipif(not HAS_OBSPAR_ARCHIVE, reason='Test requires mica obspars')
 def test_make_acq_stats():

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -689,7 +689,7 @@ def update(opt):
         logger.info("Processing obsid {}".format(obsid))
         try:
             obsid_info, acq_stats, star_info, catalog, temp = calc_stats(obsid)
-        except ValueError as e:
+        except (ValueError, IndexError) as e:
             logger.info("Skipping obsid {}: {}".format(obsid, e))
             continue
         if not len(acq_stats):

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -689,7 +689,7 @@ def update(opt):
         logger.info("Processing obsid {}".format(obsid))
         try:
             obsid_info, acq_stats, star_info, catalog, temp = calc_stats(obsid)
-        except (ValueError, IndexError) as e:
+        except Exception as e:
             logger.info("Skipping obsid {}: {}".format(obsid, e))
             continue
         if not len(acq_stats):


### PR DESCRIPTION
## Description

Skip any Exceptions in nominal processing over obsids.  The acq stats processing maneuver and dwell times don't make sense for obsid 62650 (causing IndexError) and it isn't worth the redesign of the code just now.  

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->

This is the error in flight/master on the nsm / post-nsm obsid:

```
Skipping obsid 29211: No starcheck catalog found for 29211
Processing obsid 62620
Traceback (most recent call last):
  File "/proj/sot/ska3/flight/lib/python3.10/site-packages/mica/stats/update_acq_stats.py", line 503, in calc_stats
    raise ValueError
ValueError

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/proj/sot/ska3/flight/share/mica/update_acq_stats.py", line 6, in <module>
    update_acq_stats.main()
  File "/proj/sot/ska3/flight/lib/python3.10/site-packages/mica/stats/update_acq_stats.py", line 709, in main
    update(opt)
  File "/proj/sot/ska3/flight/lib/python3.10/site-packages/mica/stats/update_acq_stats.py", line 691, in update
    obsid_info, acq_stats, star_info, catalog, temp = calc_stats(obsid)
  File "/proj/sot/ska3/flight/lib/python3.10/site-packages/mica/stats/update_acq_stats.py", line 511, in calc_stats
    multi = multi_manvr.select_overlapping(events.obsids(obsid=obsid))
  File "/proj/sot/ska3/flight/lib/python3.10/site-packages/kadi/events/models.py", line 341, in select_overlapping
    start = DateTime(events[0].tstart) - 30
IndexError: list index out of range
```

This code is awkward to setup to test, so I just made a local edit to change the "table_file" to a local h5 file, copied the current acq stats h5 to that, and confirmed that an update runs over the NSM obsid(s).


```
ska3-jeanconn-fido> python mica/stats/update_acq_stats.py 
Processing obsid 29211
Found obsid manvr at 2024:025:12:58:55.648
Found dwell at 2024:025:13:04:07.760
Skipping obsid 29211: No starcheck catalog found for 29211
Processing obsid 62620
Skipping obsid 62620: list index out of range
Processing obsid 43761
...
Processing obsid 27349
Found obsid manvr at 2024:035:00:31:34.176
Found dwell at 2024:035:01:12:27.513
calculating statistics
arranging stats into tabular data
saving stats to h5 table
Processing obsid 65522
Skipping obsid 65522: list index out of range
ska3-jeanconn-fido> 
```