### PR TITLE
in tests_acq/guide: close temp file before unlinking it

### DIFF
--- a/mica/stats/tests/test_acq_stats.py
+++ b/mica/stats/tests/test_acq_stats.py
@@ -42,6 +42,7 @@ def test_make_acq_stats():
     # Get a temporary file, but then delete it, because _save_acq_stats will only
     # make a new table if the supplied file doesn't exist
     fh, fn = tempfile.mkstemp(suffix='.h5')
+    os.close(fh)
     os.unlink(fn)
     acq_stats.table_file = fn
     obsid = 20001

--- a/mica/stats/tests/test_guide_stats.py
+++ b/mica/stats/tests/test_guide_stats.py
@@ -48,6 +48,7 @@ def test_make_gui_stats():
     # Get a temporary file, but then delete it, because _save_acq_stats will only
     # make a new table if the supplied file doesn't exist
     fh, fn = tempfile.mkstemp(suffix='.h5')
+    os.close(fh)
     os.unlink(fn)
     obsid = 20001
     obsid_info, gui, star_info, catalog, temp = update_guide_stats.calc_stats(obsid)


### PR DESCRIPTION
## Description

In tests_acq/guide: close temp file before unlinking it.

From the docs:

> [mkstemp()](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp) returns a tuple containing an OS-level handle to an open file (as would be returned by [os.open()](https://docs.python.org/3/library/os.html#os.open))

Since the file is open, it should be close before unlinking. Otherwise, one gets this error on windows:
```
        fh, fn = tempfile.mkstemp(suffix='.h5')
>       os.unlink(fn)
E       PermissionError: [WinError 32] The process cannot access the file because it is being used by another process
```

I know we would not use this on windows most probably, but still...

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [ ] Mac
- [ ] Linux
- [ ] Windows

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests

After this PR, the test do not fail at this point in Windows. They fail later because I test on a VM, and the symbolic links in `mica/archive/obspar` are not supported in the VM
