### PR TITLE
Update one remaining sybase call to use sqsh

### DIFF
--- a/mica/archive/obsid_archive.py
+++ b/mica/archive/obsid_archive.py
@@ -737,7 +737,7 @@ class ObsArchive:
         prov_data = self.get_todo_from_links(archive_dir)
         for obs in prov_data:
             # check again for multi-obis and limit to first one
-            with ska_dbi.DBI(**apstat) as db:
+            with Sqsh(**apstat) as db:
                 obis = db.fetchall(
                     "select distinct obi from obidet_0_5 where obsid = %d"
                     % obs['obsid'])


### PR DESCRIPTION
## Description

Update one remaining sybase call to use sqsh

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
ska3-jeanconn-fido> pytest
==================================================================== test session starts =====================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 108 items                                                                                                                                          

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                             [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                  [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                                  [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                                              [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                          [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                    [ 70%]
mica/report/tests/test_write_report.py .                                                                                                               [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                           [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                 [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                              [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                     [100%]

====================================================================== warnings summary ======================================================================
mica/mica/archive/tests/test_aca_l0.py::test_l0_images_meta
mica/mica/archive/tests/test_aca_l0.py::test_l0_images_meta
mica/mica/archive/tests/test_aca_l0.py::test_get_l0_images
mica/mica/archive/tests/test_aca_l0.py::test_get_l0_images
  /proj/sot/ska3/flight/lib/python3.11/site-packages/numpy/ma/core.py:429: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -9999 to uint8 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    output_value.append(np.array(fval, dtype=cdtype).item())

mica/mica/archive/tests/test_asp_l1.py::test_get_atts_time
  /proj/sot/ska3/flight/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

mica/mica/archive/tests/test_asp_l1.py::test_get_atts_time
  /proj/sot/ska3/flight/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

mica/mica/archive/tests/test_cda.py: 13 warnings
mica/mica/report/tests/test_write_report.py: 94 warnings
mica/mica/stats/tests/test_acq_stats.py: 82 warnings
mica/mica/stats/tests/test_guide_stats.py: 18 warnings
mica/mica/vv/tests/test_vv.py: 1 warning
  /proj/sot/ska3/flight/lib/python3.11/site-packages/tables/node.py:251: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    self._v_objectid = self._g_open()

mica/mica/archive/tests/test_cda.py: 13 warnings
mica/mica/report/tests/test_write_report.py: 243 warnings
mica/mica/stats/tests/test_acq_stats.py: 9 warnings
  /proj/sot/ska3/flight/lib/python3.11/site-packages/tables/table.py:1513: DeprecationWarning: `sometrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `any` instead.
    coords = [p.nrow for p in

mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /proj/sot/ska/jeanproj/git/mica/mica/report/report.py:187: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    acqs = tbl.read_where("obsid == {}".format(obsid))

mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /proj/sot/ska/jeanproj/git/mica/mica/report/report.py:197: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    guis = tbl.read_where("obsid == {}".format(obsid))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 108 passed, 484 warnings in 561.13s (0:09:21)

ska3-jeanconn-fido> git rev-parse HEAD
92938e13aa3ce4458996907df52d943db7ee456e

```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This isn't covered in unit tests.  For this tiny fix related to updating provisional data, I just live tested it on the flight archive and confirmed the code runs to completion without errors.

```
ska3-jeanconn-fido> export PYTHONPATH=/home/jeanconn/git/mica
ska3-jeanconn-fido> /proj/sot/ska3/flight/share/mica/update_obspar.py 
using 110284 for last_id
No new data
Checking for updates to obsids with provisional data
checking database status for obsid 2292 obi 0 ver 4, 
checking database status for obsid 2288 obi 0 ver 5, 
checking database status for obsid 7928 obi 0 ver 3, 
checking database status for obsid 9379 obi 0 ver 4, 
checking database status for obsid 12181 obi 0 ver 3, 
checking database status for obsid 13142 obi 0 ver 3, 
checking database status for obsid 13141 obi 0 ver 3, 
checking database status for obsid 13455 obi 0 ver 4, 
checking database status for obsid 15703 obi 0 ver 2, 
checking database status for obsid 15070 obi 0 ver 3, 
checking database status for obsid 19421 obi 0 ver 2, 
checking database status for obsid 19436 obi 0 ver 2, 
checking database status for obsid 20325 obi 0 ver 2, 
checking database status for obsid 47063 obi 0 ver 1, 
checking database status for obsid 26732 obi 0 ver 1, 
obsid dir /proj/sot/ska3/flight/data/mica/archive/obspar/26/26732_v01 already exists
retrieving data for 26732 in /proj/sot/ska3/flight/data/mica/archive/tempobs/tmpaf33f2n_
linking 26732_v01 -> /proj/sot/ska3/flight/data/mica/archive/obspar/26/26732
updating archfiles default rev to 1 for 26732
removing outdated link /proj/sot/ska3/flight/data/mica/archive/obspar/26/26732_last
checking database status for obsid 27599 obi 0 ver 2, 
checking database status for obsid 29327 obi 0 ver 1, 
obsid dir /proj/sot/ska3/flight/data/mica/archive/obspar/29/29327_v01 already exists
retrieving data for 29327 in /proj/sot/ska3/flight/data/mica/archive/tempobs/tmpid4w3_6t
linking 29327_v01 -> /proj/sot/ska3/flight/data/mica/archive/obspar/29/29327
updating archfiles default rev to 1 for 29327
removing outdated link /proj/sot/ska3/flight/data/mica/archive/obspar/29/29327_last
checking database status for obsid 43621 obi 0 ver 2, 
obsid dir /proj/sot/ska3/flight/data/mica/archive/obspar/43/43621_v02 already exists
retrieving data for 43621 in /proj/sot/ska3/flight/data/mica/archive/tempobs/tmp5dblc4qy
linking 43621_v02 -> /proj/sot/ska3/flight/data/mica/archive/obspar/43/43621
updating archfiles default rev to 2 for 43621
removing outdated link /proj/sot/ska3/flight/data/mica/archive/obspar/43/43621_last
```
