### PR TITLE
Remove np.str calls

### DIFF
--- a/mica/centroid_dashboard.py
+++ b/mica/centroid_dashboard.py
@@ -435,7 +435,7 @@ def get_cd_dir(obsid, data_root):
     if obsid == -1:
         return ""
 
-    cd_obsid_root = os.path.join(data_root, np.str(obsid)[:2], f"{obsid}")
+    cd_obsid_root = os.path.join(data_root, str(obsid)[:2], f"{obsid}")
 
     if not os.path.exists(cd_obsid_root):
         os.makedirs(cd_obsid_root)
@@ -957,10 +957,10 @@ def make_html(row_obsid, rows_slot, obs_dir):
     aber_z = row_obsid['aber_z']
     mean_date = row_obsid['mean_date']
 
-    cd_preceding_root = os.path.join('../../', np.str(obsid_preceding)[:2], f"{obsid_preceding}")
-    cd_next_root = os.path.join('../../', np.str(obsid_next)[:2], f"{obsid_next}")
+    cd_preceding_root = os.path.join('../../', str(obsid_preceding)[:2], f"{obsid_preceding}")
+    cd_next_root = os.path.join('../../', str(obsid_next)[:2], f"{obsid_next}")
 
-    star_path_root = os.path.join(MICA_REPORTS, np.str(obsid)[:2], f"{obsid}")
+    star_path_root = os.path.join(MICA_REPORTS, str(obsid)[:2], f"{obsid}")
 
     if obsid_preceding == -9999:
         preceding_obsid_link = ""
@@ -1158,8 +1158,8 @@ def make_special_case_html(metrics_obsid, obs_dir, info=''):
     obsid_preceding = metrics_obsid['obsid_preceding']
     obsid_next = metrics_obsid['obsid_next']
 
-    cd_preceding_root = os.path.join('../../', np.str(obsid_preceding)[:2], f"{obsid_preceding}")
-    cd_next_root = os.path.join('../../', np.str(obsid_next)[:2], f"{obsid_next}")
+    cd_preceding_root = os.path.join('../../', str(obsid_preceding)[:2], f"{obsid_preceding}")
+    cd_next_root = os.path.join('../../', str(obsid_next)[:2], f"{obsid_next}")
 
     if obsid_preceding == -9999:
         preceding_obsid_link = ""


### PR DESCRIPTION
## Description

Remove np.str calls

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Centroid dashboard fails with numpy error without this change.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
(ska3-masters) jeanconn-fido> export SKA=/proj/sot/ska
(ska3-masters) jeanconn-fido> pytest
============================================================================ test session starts =============================================================================
platform linux -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 108 items                                                                                                                                                          

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                             [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                  [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                                                  [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                                                              [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                                          [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                                    [ 70%]
mica/report/tests/test_write_report.py .                                                                                                                               [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                           [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                 [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                              [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                                     [100%]

============================================================================== warnings summary ==============================================================================
mica/mica/archive/tests/test_aca_l0.py::test_l0_images_meta
mica/mica/archive/tests/test_aca_l0.py::test_l0_images_meta
mica/mica/archive/tests/test_aca_l0.py::test_get_l0_images
mica/mica/archive/tests/test_aca_l0.py::test_get_l0_images
  /fido.real/conda/envs/ska3-masters/lib/python3.11/site-packages/numpy/ma/core.py:429: DeprecationWarning: NumPy will stop allowing conversion of out-of-bound Python integers to integer arrays.  The conversion of -9999 to uint8 will fail in the future.
  For the old behavior, usually:
      np.array(value).astype(dtype)
  will give the desired result (the cast overflows).
    output_value.append(np.array(fval, dtype=cdtype).item())

mica/mica/archive/tests/test_asp_l1.py::test_get_atts_time
  /fido.real/conda/envs/ska3-masters/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

mica/mica/archive/tests/test_asp_l1.py::test_get_atts_time
  /fido.real/conda/envs/ska3-masters/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================ 108 passed, 6 warnings in 514.86s (0:08:34) =================================================================
(ska3-masters) jeanconn-fido> git rev-parse HEAD
8fbe6fad68f960de5578b9823e23a18676a51d4e
```


Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
