### PR TITLE
Handle filling aca image array differently

### DIFF
--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -243,7 +243,7 @@ def get_l0_images(start, stop, slot, imgsize=None, columns=None):
     imgraws = dat["IMGRAW"].filled()
 
     imgs = []
-    for row,  imgraw in zip(dat, imgraws):
+    for row, imgraw in zip(dat, imgraws):
         imgraw = imgraw.reshape(8, 8)
         sz = row["IMGSIZE"]
         if sz < 8:


### PR DESCRIPTION
## Description

Handle filling aca image array differently

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes #293 

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
 

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
ska3-jeanconn-fido> git rev-parse HEAD
a1ca210964cbf815a3adce67bcd5323723b6f9c9
ska3-jeanconn-fido> pytest
================================================================= test session starts ==================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 108 items                                                                                                                                    

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                       [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                            [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                            [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                                        [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                    [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                              [ 70%]
mica/report/tests/test_write_report.py .                                                                                                         [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                     [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                           [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                        [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                               [100%]

=========================================================== 108 passed in 517.20s (0:08:37)
```



Independent check of unit tests by Javier
- [x] Linux

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
