### PR TITLE
Don't warn if kadi user can't access db

### DIFF
--- a/mica/report/tests/test_write_report.py
+++ b/mica/report/tests/test_write_report.py
@@ -20,8 +20,8 @@ try:
 except Exception as e:
     HAS_SYBASE_ACCESS = False
 
-    # If the user should have access, warn about the issue.
-    if on_head_network():
+    # If the user should have access, warn about the issue. kadi user does not have access.
+    if on_head_network() and user != 'kadi':
         warn(f"On HEAD but Sqsh did not work. {e}")
 
 


### PR DESCRIPTION
## Description

Don't warn if kadi user can't access db in testing.

We could also just catch the warning in ska_testr, but I think maybe it is most useful here to not emit it.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Without this, you get
```
mica/report/tests/test_write_report.py:25
  /proj/sot/ska/jeanproj/git/mica/mica/report/tests/test_write_report.py:25: UserWarning: On HEAD but Sqsh did not work. Unable to read inferred sqshrc file /proj/sot/ska/data/aspect_authorization/sqsh-sqlsao-axafvv-kadi
    warn(f"On HEAD but Sqsh did not work. {e}")
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux

```
ska3-jeanconn-kady> git rev-parse HEAD
061254c8e7696eb87b49f4388775a06ef9779a90
ska3-jeanconn-kady> pytest
============================================================================== test session starts ===============================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 108 items                                                                                                                                                              

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                 [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                      [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                                                      [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                                                                  [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                                              [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                                        [ 70%]
mica/report/tests/test_write_report.py .                                                                                                                                   [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                               [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                     [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                  [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                                         [100%]

======================================================================== 108 passed in 378.49s (0:06:18
```

and as kadi user (warnings related to running out of a dir owned by jeanconn not the sqsh issue)
```
kadi-fido> pytest
=================================================================== test session starts ===================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 108 items                                                                                                                                       

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                          [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                               [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                               [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                                           [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                       [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                 [ 70%]
mica/report/tests/test_write_report.py s                                                                                                            [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                        [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                              [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                           [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                  [100%]

==================================================================== warnings summary =====================================================================
../../../../ska3/flight/lib/python3.11/site-packages/_pytest/cacheprovider.py:451
  /proj/sot/ska3/flight/lib/python3.11/site-packages/_pytest/cacheprovider.py:451: PytestCacheWarning: cache could not write path /proj/sot/ska/jeanproj/git/.pytest_cache/v/cache/nodeids: [Errno 13] Permission denied: '/proj/sot/ska/jeanproj/git/.pytest_cache/v/cache/nodeids'
    config.cache.set("cache/nodeids", sorted(self.cached_nodeids))

../../../../ska3/flight/lib/python3.11/site-packages/_pytest/stepwise.py:56
  /proj/sot/ska3/flight/lib/python3.11/site-packages/_pytest/stepwise.py:56: PytestCacheWarning: cache could not write path /proj/sot/ska/jeanproj/git/.pytest_cache/v/cache/stepwise: [Errno 13] Permission denied: '/proj/sot/ska/jeanproj/git/.pytest_cache/v/cache/stepwise'
    session.config.cache.set(STEPWISE_CACHE_DIR, [])

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 107 passed, 1 skipped, 2 warnings in 447.99s (0:07:27
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
