### PR TITLE
Use full agasc for lookups for guide/acq stats

### DIFF
--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -149,11 +149,10 @@ def _deltas_vs_obc_quat(vals, times, catalog):
             continue
         try:
             star = agasc.get_star(agasc_id, date=times[0],
-                                  agasc_file='miniagasc_*',
+                                  agasc_file='agasc*',
                                   use_supplement=False)
-        except:
-            logger.info("agasc error on slot {}:{}".format(
-                    slot, sys.exc_info()[0]))
+        except Exception as e:
+            logger.info(f"agasc error on slot {slot} id {agasc_id} err {e} {type(e)}")
             continue
         ra = star['RA_PMCORR']
         dec = star['DEC_PMCORR']

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -180,11 +180,10 @@ def _deltas_vs_obc_quat(vals, times, catalog):
         try:
             # This is not perfect for star catalogs for agasc 1.4 and 1.5
             star = agasc.get_star(agasc_id, date=times[0],
-                                  agasc_file='miniagasc_*',
+                                  agasc_file='agasc*',
                                   use_supplement=False)
-        except:
-            logger.info("agasc error on slot {}:{}".format(
-                    slot, sys.exc_info()[0]))
+        except Exception as e:
+            logger.info(f"agasc error on slot {slot} id {agasc_id} err {e} {type(e)}")
             continue
         ra = star['RA_PMCORR']
         dec = star['DEC_PMCORR']


### PR DESCRIPTION
## Description

Use full agasc for lookups for guide/acq stats.  With the healpix improvements, I don't think the speed difference matters for using the miniagasc.

I also don't see a driver to use different AGASC versions for *most* uses of the guide and acq stats of this time, given the small number of stars with very different positions - though we may want to review this in more detail if we do a full recalculation of the statistics. With the positions updates in AGASC 1.8 there would really be three positions, the observed centroids of the star, the expected position at the time the star catalog was constructed, and our best AGASC 1.8 estimate of the star position.


<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes small issue in testing where a star in obsid 19386 is not in the 1p8 miniagasc and the ska_testr test log checking fails on the  error and error type printed to output.
```
calculating statistics
Found obsid manvr at 2016:353:16:03:25.163
Found dwell at 2016:353:16:32:50.725
agasc error on slot 7:<class 'agasc.agasc.IdNotFound'>
agasc error on slot 7:<class 'agasc.agasc.IdNotFound'>
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
b2a1c1734cd89044497e10622cf0f876ebae5e03
ska3-jeanconn-fido> pytest -vs
================================================================================ test session starts =================================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0 -- /proj/sot/ska3/flight/bin/python3.11
cachedir: .pytest_cache
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 108 items                                                                                                                                                                  

mica/archive/tests/test_aca_dark_cal.py::test_date_to_dark_id PASSED
mica/archive/tests/test_aca_dark_cal.py::test_dark_id_to_date PASSED
mica/archive/tests/test_aca_dark_cal.py::test_dark_temp_scale PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_id PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_image[True-True] PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_image[True-False] PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_image[False-True] PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_image[False-False] PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_props[True-True] PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_props[True-False] PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_props[False-True] PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_props[False-False] PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_props_table PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_props_table_acdc PASSED
mica/archive/tests/test_aca_dark_cal.py::test_get_dark_cal_props_table_mixed PASSED
mica/archive/tests/test_aca_dark_cal.py::test_scalar PASSED
mica/archive/tests/test_aca_dark_cal.py::test_vectorized PASSED
mica/archive/tests/test_aca_dark_cal.py::test_limits PASSED
mica/archive/tests/test_aca_hdr3.py::test_MSIDset PASSED
mica/archive/tests/test_aca_l0.py::test_l0_images_meta PASSED
mica/archive/tests/test_aca_l0.py::test_get_l0_images PASSED
mica/archive/tests/test_aca_l0.py::test_get_slot_data_8x8 PASSED
mica/archive/tests/test_asp_l1.py::test_get_atts_obsid[14333] PASSED
mica/archive/tests/test_asp_l1.py::test_get_atts_obsid[15175] PASSED
mica/archive/tests/test_asp_l1.py::test_get_atts_obsid[5438] PASSED
mica/archive/tests/test_asp_l1.py::test_get_atts_obsid[2121] PASSED
mica/archive/tests/test_asp_l1.py::test_get_atts_time PASSED
mica/archive/tests/test_asp_l1.py::test_update_l1_archive PASSED
mica/archive/tests/test_asp_l1.py::test_get_atts_filter PASSED
mica/archive/tests/test_cda.py::test_ocat_details_local_all PASSED
mica/archive/tests/test_cda.py::test_ocat_details_local_where PASSED
mica/archive/tests/test_cda.py::test_ocat_local_unicode PASSED
mica/archive/tests/test_cda.py::test_ocat_special_query PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match1[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match1[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match1[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match2[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match2[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match2[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match3[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match3[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match3[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match4[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match4[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_filtering_no_match4[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_obsid_auto[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_obsid_auto[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_obsid_auto[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_obsid_table[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_obsid_table[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_obsid_table[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_no_match_auto[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_no_match_auto[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_no_match_auto[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_name1[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_name1[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_name1[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_name2[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_name2[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_name2[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_coords[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_coords[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_resolve_coords[web-summary] PASSED
mica/archive/tests/test_cda.py::test_ocat_no_match_table[local-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_no_match_table[web-detail] PASSED
mica/archive/tests/test_cda.py::test_ocat_no_match_table[web-summary] PASSED
mica/archive/tests/test_cda.py::test_get_archive_file_list PASSED
mica/archive/tests/test_cda.py::test_get_proposal_abstract PASSED
mica/archive/tests/test_cda.py::test_get_proposal_abstract_fail PASSED
mica/archive/tests/test_cda.py::test_bad_return_type[local-detail] PASSED
mica/archive/tests/test_cda.py::test_bad_return_type[web-detail] PASSED
mica/archive/tests/test_cda.py::test_bad_return_type[web-summary] PASSED
mica/archive/tests/test_obspar.py::test_get_obsids PASSED
mica/report/tests/test_write_report.py::test_write_reports Making report for 20001
Writing out full report to /tmp/tmp9dmyh6_1/20/20001/index.html
Making report for 15175
Writing out full report to /tmp/tmp9dmyh6_1/15/15175/index.html
Making report for 54778
Processing ER; no V&V available
Writing out full report to /tmp/tmp9dmyh6_1/54/54778/index.html
Making report for 44077
No starcheck catalog or no starcat.  Writing out OCAT info only
No starcat
Writing out full report to /tmp/tmp9dmyh6_1/44/44077/index.html
PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range start=2017:001:06:06:15.293 dur=26759
start=2017:001:14:02:48.695 dur=25157
start=2017:001:21:24:14.696 dur=50367
start=2017:002:11:31:59.299 dur=456
PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_obsid_catalog_fetch[test_case0] PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_obsid_catalog_fetch[test_case1] PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_obsid_catalog_fetch[test_case2] PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_obsid_catalog_fetch_dark_cal PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_monitor_fetch PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_get_starcheck_methods PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_get_starcheck_vs_kadi PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_get_starcheck_db_obsid PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_get_starcheck_db_obsid_fail PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_get_starcheck_scs107 PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_get_starcheck_with_mp_dir PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_get_starcheck_for_no_star_catalog PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_get_starcheck_for_no_starcheck_entry PASSED
mica/starcheck/tests/test_catalog_fetches.py::test_load_name_to_mp_dir PASSED
mica/stats/tests/test_acq_stats.py::test_single_star_stats PASSED
mica/stats/tests/test_acq_stats.py::test_calc_stats Found obsid manvr at 2016:035:20:33:22.927
Found dwell at 2016:035:20:57:39.964
calculating statistics
Found obsid manvr at 2013:099:09:11:47.967
Found dwell at 2013:099:09:32:32.829
calculating statistics
Found obsid manvr at 2005:111:17:15:28.099
Found dwell at 2005:111:18:01:36.111
calculating statistics
Found obsid manvr at 2016:353:16:03:25.163
Found dwell at 2016:353:16:32:50.725
calculating statistics
Found obsid manvr at 2024:025:12:58:55.648
Found dwell at 2024:025:13:04:07.760
PASSED
mica/stats/tests/test_acq_stats.py::test_make_acq_stats Found obsid manvr at 2017:169:18:22:47.751
Found dwell at 2017:169:18:54:50.138
calculating statistics
arranging stats into tabular data
saving stats to h5 table
PASSED
mica/stats/tests/test_guide_stats.py::test_read_stats PASSED
mica/stats/tests/test_guide_stats.py::test_calc_stats Found obsid manvr at 2016:035:20:33:22.927
Found dwell at 2016:035:20:57:39.964
calculating statistics
PASSED
mica/stats/tests/test_guide_stats.py::test_calc_stats_with_bright_trans Found obsid manvr at 2015:264:02:29:27.143
Found dwell at 2015:264:03:17:56.606
calculating statistics
PASSED
mica/stats/tests/test_guide_stats.py::test_make_gui_stats Found obsid manvr at 2017:169:18:22:47.751
Found dwell at 2017:169:18:54:50.138
calculating statistics
arranging stats into tabular data
saving stats to h5 table
PASSED
mica/vv/tests/test_vv.py::test_get_vv_dir PASSED
mica/vv/tests/test_vv.py::test_get_vv_files PASSED
mica/vv/tests/test_vv.py::test_get_rms_data PASSED
mica/vv/tests/test_vv.py::test_get_vv PASSED
mica/vv/tests/test_vv.py::test_run_vv Generating V&V for obsid 2121
Processing aspect interval pcadf090549491N003
Processing GOOD       star in slot 3
Processing GOOD       star in slot 4
Processing GOOD       star in slot 5
Processing GOOD       star in slot 6
Processing GOOD       star in slot 7
Processing fid ACIS-S-2   in slot 0
Processing fid ACIS-S-4   in slot 1
Processing fid ACIS-S-5   in slot 2
Could not determine aspect_1_id/date from Sybase database
PASSED
mica/vv/tests/test_vv.py::test_run_vv_omitted_slot Generating V&V for obsid 19991
Processing aspect interval pcadf602085691N003
Could not get OCAT stars from database
Skipping checks for missing slots
Processing GOOD       star in slot 3
Processing GOOD       star in slot 4
Processing GOOD       star in slot 5
Processing GOOD       star in slot 6
Processing fid ACIS-I-1   in slot 0
Processing fid ACIS-I-5   in slot 1
Processing fid ACIS-I-6   in slot 2
Could not determine aspect_1_id/date from Sybase database
PASSED
mica/vv/tests/test_vv.py::test_run_vv_multi_interval Generating V&V for obsid 18980
Processing aspect interval pcadf601730061N003
Processing GOOD       star in slot 3
Processing GOOD       star in slot 4
Processing GOOD       star in slot 5
Processing GOOD       star in slot 6
Processing GOOD       star in slot 7
Processing fid ACIS-I-1   in slot 0
Processing fid ACIS-I-4   in slot 1
Processing fid ACIS-I-5   in slot 2
Could not determine aspect_1_id/date from Sybase database
PASSED
mica/vv/tests/test_vv.py::test_run_vv_omitted_fid Generating V&V for obsid 18978
Processing aspect interval pcadf604310171N003
Could not get OCAT stars from database
Skipping checks for missing slots
Processing GOOD       star in slot 3
Processing GOOD       star in slot 4
Processing GOOD       star in slot 5
Processing GOOD       star in slot 6
Processing GOOD       star in slot 7
Processing fid ACIS-I-4   in slot 1
Processing fid ACIS-I-5   in slot 2
Could not determine aspect_1_id/date from Sybase database
PASSED
mica/vv/tests/test_vv.py::test_run_vv_7_track_slots Generating V&V for obsid 19847
Processing aspect interval pcadf611706911N002
Could not get OCAT stars from database
Skipping checks for missing slots
Processing GOOD       star in slot 3
Processing GOOD       star in slot 4
Processing GOOD       star in slot 5
Processing GOOD       star in slot 6
Processing fid HRC-I-1    in slot 0
Processing fid HRC-I-2    in slot 1
Processing fid HRC-I-3    in slot 2
Could not determine aspect_1_id/date from Sybase database
PASSED

========================================================================== 108 passed in 526.25s (0:08:46
```




Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
