### PR TITLE
Fix V&V processing error with Sqsh

### DIFF
--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -268,7 +268,7 @@ class Obi(object):
         logger.info("Saved JSON to {}".format(file))
 
     def slots_to_db(self):
-        if self.info()["aspect_1_id"] is None:
+        if self.info().get("aspect_1_id") is None:
             logger.warning(
                 "Database save not implemented for obsids without aspect_1_ids"
             )
@@ -300,7 +300,7 @@ class Obi(object):
 
     def slots_to_table(self):
         save = self.info()
-        if save["aspect_1_id"] is None:
+        if save.get("aspect_1_id") is None:
             logger.warning("Table save not implemented for obsids without aspect_1_ids")
             return
         mean_aacccdpt = self._get_ccd_temp(save["tstart"], save["tstop"])

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -194,16 +194,15 @@ class Obi(object):
     # this should probably be handled in mica.archive.asp_l1
     @staticmethod
     def _asp1_lookup(obsid, obi, revision):
-        apstat = Sqsh(dbi="sybase", server="sqlsao", database="axafapstat")
-        # take these from the first aspect solution file header
-        aspect_1 = apstat.fetchall(
-            """SELECT * FROM aspect_1
-                                      WHERE obsid = {obsid}
-                                      AND obi = {obi}
-                                      AND revision = {revision}
-                                   """.format(obsid=obsid, obi=obi, revision=revision)
-        )
-        apstat.conn.close()
+        with Sqsh(dbi="sybase", server="sqlsao", database="axafapstat") as apstat:
+            # take these from the first aspect solution file header
+            aspect_1 = apstat.fetchall(
+                """SELECT * FROM aspect_1
+                                        WHERE obsid = {obsid}
+                                        AND obi = {obi}
+                                        AND revision = {revision}
+                                    """.format(obsid=obsid, obi=obi, revision=revision)
+            )
         if len(aspect_1) > 1:
             raise ValueError("More than one entry found for obsid/obi/rev in aspect_1")
         if len(aspect_1) == 0:
@@ -932,13 +931,12 @@ class AspectInterval(object):
     def _read_ocat_stars(self):
         obsid = int(self.asol_header["OBS_ID"])
         obi = int(self.asol_header["OBI_NUM"])
-        ocat_db = Sqsh(dbi="sybase", server="sqlsao", database="axafocat")
-        stars = ocat_db.fetchall(
-            "select * from stars where "
-            "obsid = {} and obi = {} "
-            "and type != 0".format(obsid, obi)
-        )
-        ocat_db.conn.close()
+        with Sqsh(dbi="sybase", server="sqlsao", database="axafocat") as ocat_db:
+            stars = ocat_db.fetchall(
+                "select * from stars where "
+                "obsid = {} and obi = {} "
+                "and type != 0".format(obsid, obi)
+            )
         if len(np.unique(stars["obi"])) > 1:
             raise ValueError(
                 "Multi-obi observation.  OCAT stars unhelpful to identify missing slot"


### PR DESCRIPTION
## Description

Fix V&V processing error with Sqsh.  
Put the Sqsh calls in context managers instead of using an explicit conn.close that doesn't work on Sqsh.

Also change a couple of checks to use get() instead of checking "if self.info()["aspect_1_id"] is None" because for the nominal cases where there is a check on that value and the value doesn't exist, the key is also not defined and the error handling should be the same in that case.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue that V&V processing was going through its paces but not getting the right information to update the status table.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
(ska3-mica) jeanconn-fido> pytest
======================================================== test session starts ========================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 108 items                                                                                                                 

mica/archive/tests/test_aca_dark_cal.py ..................                                                                    [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                         [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                         [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                     [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                 [ 69%]
mica/archive/tests/test_obspar.py .                                                                                           [ 70%]
mica/report/tests/test_write_report.py .                                                                                      [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                  [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                        [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                     [ 91%]
mica/vv/tests/test_vv.py .........                                                                                            [100%]

================================================== 108 passed in 535.22s (0:08:55)
```

Independent check of unit tests by Javier
- [x] Linux:

```
jgonzale mica $ pytest mica
==================================================================== test session starts ====================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.3.0, timeout-2.2.0
collected 108 items                                                                                                                                         

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                            [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                 [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                                 [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                                             [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                         [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                   [ 70%]
mica/report/tests/test_write_report.py .                                                                                                              [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                          [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                             [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                    [100%]

===================================================================== warnings summary ======================================================================
mica/mica/archive/tests/test_cda.py: 13 warnings
mica/mica/report/tests/test_write_report.py: 94 warnings
mica/mica/stats/tests/test_acq_stats.py: 82 warnings
mica/mica/stats/tests/test_guide_stats.py: 18 warnings
mica/mica/vv/tests/test_vv.py: 2 warnings
  /proj/sot/ska3/flight/lib/python3.11/site-packages/tables/node.py:251: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    self._v_objectid = self._g_open()

mica/mica/archive/tests/test_cda.py: 13 warnings
mica/mica/report/tests/test_write_report.py: 243 warnings
mica/mica/stats/tests/test_acq_stats.py: 9 warnings
  /proj/sot/ska3/flight/lib/python3.11/site-packages/tables/table.py:1513: DeprecationWarning: `sometrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `any` instead.
    coords = [p.nrow for p in

mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /proj/sot/ska/jgonzalez/git/mica/mica/report/report.py:203: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    acqs = tbl.read_where("obsid == {}".format(obsid))

mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /proj/sot/ska/jgonzalez/git/mica/mica/report/report.py:213: DeprecationWarning: `alltrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `all` instead.
    guis = tbl.read_where("obsid == {}".format(obsid))

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================= 108 passed, 479 warnings in 351.86s (0:05:51) =======================================================
jgonzale mica $ git rev-parse HEAD 
3e2472e28bf50eec8a2512e291c4a099b1f6070c
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
While I prefer not to test "live", I did so here.  Old code when unhandled does:
```
obsid dir /fido.real/conda/envs/ska3-flight-2024.1rc4/data/mica/archive/vv/01/01456_v06 already exists
moved VV files to /fido.real/conda/envs/ska3-flight-2024.1rc4/data/mica/archive/vv/01/01456_v06
removed directory /fido.real/conda/envs/ska3-flight-2024.1rc4/data/mica/archive/tempvv/tmpb4fq4trw
---------------------------------------------------------------------------
KeyError                                  Traceback (most recent call last)
Cell In[3], line 1
----> 1 mica.vv.process.process(1456, 6)

File /proj/sot/ska/jeanproj/git/mica/mica/vv/process.py:250, in process(obsid, version)
    248 tbl = h5.get_node("/", "vv")
    249 obi.set_tbl(tbl)
--> 250 obi.slots_to_table()
    251 tbl.flush()
    252 h5.flush()

File /proj/sot/ska/jeanproj/git/mica/mica/vv/core.py:304, in Obi.slots_to_table(self)
    302 def slots_to_table(self):
    303     save = self.info()
--> 304     if save["aspect_1_id"] is None:
    305         logger.warning("Table save not implemented for obsids without aspect_1_ids")
    306         return

KeyError: 'aspect_1_id'
```
New code updates correctly
```
obsid dir /fido.real/conda/envs/ska3-flight-2024.1rc4/data/mica/archive/vv/01/01456_v06 already exists
moved VV files to /fido.real/conda/envs/ska3-flight-2024.1rc4/data/mica/archive/vv/01/01456_v06
removed directory /fido.real/conda/envs/ska3-flight-2024.1rc4/data/mica/archive/tempvv/tmpug65mcrx
obsid 1456 is in table
updating obsid 1456 rev 6 in place
```
