### PR TITLE
Fix a processing error in acq and guide stats 

### DIFF
--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -481,7 +481,7 @@ def _get_obsids_to_update(check_missing=False):
         try:
             with tables.open_file(table_file, "r") as h5:
                 tbl = h5.get_node("/", "data")
-            last_tstart = tbl.cols.guide_tstart[tbl.colindexes["guide_tstart"][-1]]
+                last_tstart = tbl.cols.guide_tstart[tbl.colindexes["guide_tstart"][-1]]
         except Exception:
             last_tstart = "2002:012:12:00:00"
         kadi_obsids = events.obsids.filter(start=last_tstart)

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -411,7 +411,7 @@ def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop
         try:
             with tables.open_file(table_file, "r") as h5:
                 tbl = h5.get_node("/", "data")
-            last_tstart = tbl.cols.kalman_tstart[tbl.colindexes["kalman_tstart"][-1]]
+                last_tstart = tbl.cols.kalman_tstart[tbl.colindexes["kalman_tstart"][-1]]
         except Exception:
             last_tstart = start if start is not None else "2002:012:12:00:00"
         kadi_obsids = events.obsids.filter(start=last_tstart, stop=stop)

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -411,7 +411,9 @@ def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop
         try:
             with tables.open_file(table_file, "r") as h5:
                 tbl = h5.get_node("/", "data")
-                last_tstart = tbl.cols.kalman_tstart[tbl.colindexes["kalman_tstart"][-1]]
+                last_tstart = tbl.cols.kalman_tstart[
+                    tbl.colindexes["kalman_tstart"][-1]
+                ]
         except Exception:
             last_tstart = start if start is not None else "2002:012:12:00:00"
         kadi_obsids = events.obsids.filter(start=last_tstart, stop=stop)


### PR DESCRIPTION
## Description

Fix a processing error in acq and guide stats. This looks like a small bug introduced by #300 .  There's obviously more than one way to do the fix, but tbl.cols doesn't exist for a closed tbl.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
I've been testing in a ska3-masters

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
jeanconn-fido> git rev-parse HEAD
ea27feae6766183826d0c3e5c9a5ef9601958e9e
jeanconn-fido> pytest
========================================================= test session starts =========================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 108 items                                                                                                                   

mica/archive/tests/test_aca_dark_cal.py ..................                                                                      [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                           [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                           [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                       [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                   [ 69%]
mica/archive/tests/test_obspar.py .                                                                                             [ 70%]
mica/report/tests/test_write_report.py .                                                                                        [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                    [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                          [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                       [ 91%]
mica/vv/tests/test_vv.py .........                                                                                              [100%]

=================================================== 108 passed in 531.20s (0:08:51)
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Functional testing just verifies that without these fixes, the methods for determining the obsids to update just return all the obsids since 2002.  In 'vv-error' branch and 'master':
```
In [1]: import mica.stats.update_acq_stats
obs
In [2]: obsids = mica.stats.update_acq_stats._get_obsids_to_update()
len
In [3]: len(obsids)
Out[3]: 41028

In [4]: import mica.stats.update_guide_stats

In [5]: obsids = mica.stats.update_guide_stats._get_obsids_to_update(table_file='/proj/sot/ska/data/guide_stats/guide_stats.h5')

In [6]: len(obsids)
Out[6]: 41028
```
In this branch
```
In [1]: import mica.stats.update_guide_stats

In [2]: obsids = mica.stats.update_guide_stats._get_obsids_to_update(table_file='/proj/sot/ska/data/guide_stats/guide_stats.h5')

In [3]: len(obsids)
Out[3]: 17

In [4]: import mica.stats.update_acq_stats

In [5]: obsids = mica.stats.update_acq_stats._get_obsids_to_update()

In [6]: len(obsids)
Out[6]: 46
```

