### PR TITLE
Fix truncated V&V html column

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -307,6 +307,9 @@ def official_vv_notes(obsid, summary):
 
     all_vv["aspect_review"] = None
 
+    # Convert all_vv to a list of dictionaries
+    all_vv = [dict(row) for row in all_vv]
+
     for report in all_vv:
         aspect_rev = vv_db.fetchone(
             f"select * from vvreview where vvid = {report['vvid']}"


### PR DESCRIPTION
## Description

Fix "official V&V" truncated V&V html column

This fixes broken information in the "official" V&V table and will also keep the StringTruncateWarnings out of the log checking.  This was a missed side-effect of the transition to ska_dbi.Sqsh.  Since the value of "comments" can change later to a much longer string, and since this is generally a short list of records anyway, the V&V info can just be used as a dictionary instead of an astropy table.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->
In a relatively recent ska3-masters

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
jeanconn-fido> pytest
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 108 items                                                                                                                                                                                               

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                                                  [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                                                       [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                                                                                       [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                                                                                                   [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                                                                               [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                                                                         [ 70%]
mica/report/tests/test_write_report.py .                                                                                                                                                                    [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                                                                [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                                                      [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                                                   [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                                                                          [100%]

========================================================================================= 108 passed in 531.75s (0:08:51) =========================================================================================
jeanconn-fido> git rev-parse HEAD
52f59a140c9d9a851da7c0bd116128637d8e6491
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Without the fix, the official V&V table for obsid 30477 looks like this
<img width="529" alt="Screenshot 2024-10-09 at 2 00 05 PM" src="https://github.com/user-attachments/assets/521f0513-1cc4-4907-ae82-a2eb5ec497fa">

With the fix it is back to this
<img width="609" alt="Screenshot 2024-10-09 at 2 02 48 PM" src="https://github.com/user-attachments/assets/2f463d8a-c2cc-4ab9-aadd-add7509a53b6">



