### PR TITLE
Open up regex on file name and glob to work with CP data

### DIFF
--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -377,7 +377,7 @@ class Obi(object):
             self.obspar["tstop"] <= header["TSTART"]
         ):
             return None
-        aiid_match = re.search(r"(pcadf\d+[^_]*)_", asol_file)
+        aiid_match = re.search(r"(pcad\w\d+[^_]*)_", asol_file)
         if aiid_match:
             return dict(id=aiid_match.group(1), dir=obsdir)
 
@@ -946,7 +946,7 @@ class AspectInterval(object):
     def _identify_missing_slot(self, slot):
         datadir = self.aspdir
         adat_files = glob(
-            os.path.join(datadir, "pcadf*N???_adat{}1.fits*".format(slot))
+            os.path.join(datadir, "pcad*N???_adat{}1.fits*".format(slot))
         )
         if not len(adat_files):
             return None

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -945,9 +945,7 @@ class AspectInterval(object):
 
     def _identify_missing_slot(self, slot):
         datadir = self.aspdir
-        adat_files = glob(
-            os.path.join(datadir, "pcad*N???_adat{}1.fits*".format(slot))
-        )
+        adat_files = glob(os.path.join(datadir, "pcad*N???_adat{}1.fits*".format(slot)))
         if not len(adat_files):
             return None
         hdulist = pyfits.open(adat_files[0])


### PR DESCRIPTION
## Description

Open up regex on file name and glob to work with Custom Process data.

This ends up coming up when Dale sends files for review for dark current checks etc, as the custom process files end up with axafm names or pcadm names or other variants.  I don't see a downside to just opening these expressions and globs up a bit.


## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
jeanconn-fido> git rev-parse HEAD
55508a65cd334eba7dc8998d6b01a99e87319ad2
jeanconn-fido> pytest
=============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.11.8, pytest-7.4.4, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 108 items                                                                                                                                                                                               

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                                                  [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                                                       [ 17%]
mica/archive/tests/test_aca_l0.py ...                                                                                                                                                                       [ 20%]
mica/archive/tests/test_asp_l1.py .......                                                                                                                                                                   [ 26%]
mica/archive/tests/test_cda.py ..............................................                                                                                                                               [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                                                                         [ 70%]
mica/report/tests/test_write_report.py .                                                                                                                                                                    [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                                                                [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                                                      [ 87%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                                                   [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                                                                          [100%]

========================================================================================= 108 passed in 522.09s (0:08:42)
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Functionally I tested this by successfully reading in the CP1107 data today.