### PR TITLE
Exclude new IMG_VCDUCTR image data from col comparison

### DIFF
--- a/mica/archive/tests/test_aca_l0.py
+++ b/mica/archive/tests/test_aca_l0.py
@@ -56,7 +56,7 @@ def test_get_aca_images():
     assert set(imgs_mica["COMMPROG_REPEAT"]) == {0, 1}
 
     for colname in imgs_maude.colnames:
-        if colname in ["IMG_VCDUCTR", "IMG_TIME"]:
+        if colname in ["IMG_VCDUCTR"]:
             # These derived cols are not matched in mica at this time
             continue
         if imgs_maude[colname].dtype.kind == "f":
@@ -96,7 +96,7 @@ def test_get_aca_images_empty():
     assert len(imgs_mica) == 0
     assert type(imgs_mica) is Table
     maude_cols = imgs_maude.colnames.copy()
-    for extra_maude_col in ["IMG_VCDUCTR", "IMG_TIME"]:
+    for extra_maude_col in ["IMG_VCDUCTR"]:
         if extra_maude_col in maude_cols:
             maude_cols.remove(extra_maude_col)
     assert set(maude_cols).issubset(imgs_mica.colnames)

--- a/mica/archive/tests/test_aca_l0.py
+++ b/mica/archive/tests/test_aca_l0.py
@@ -56,8 +56,8 @@ def test_get_aca_images():
     assert set(imgs_mica["COMMPROG_REPEAT"]) == {0, 1}
 
     for colname in imgs_maude.colnames:
-        if colname == "END_INTEG_TIME":
-            # Currently this is off by INTEG/2
+        if colname in ["IMG_VCDUCTR", "IMG_TIME"]:
+            # These derived cols are not matched in mica at this time
             continue
         if imgs_maude[colname].dtype.kind == "f":
             assert np.allclose(
@@ -95,7 +95,11 @@ def test_get_aca_images_empty():
     # zero-length table with the required columns to match maude_decom
     assert len(imgs_mica) == 0
     assert type(imgs_mica) is Table
-    assert set(imgs_maude.colnames).issubset(imgs_mica.colnames)
+    maude_cols = imgs_maude.colnames.copy()
+    for extra_maude_col in ["IMG_VCDUCTR", "IMG_TIME"]:
+        if extra_maude_col in maude_cols:
+            maude_cols.remove(extra_maude_col)
+    assert set(maude_cols).issubset(imgs_mica.colnames)
 
 
 has_l0_2007_archive = os.path.exists(os.path.join(aca_l0.CONFIG["data_root"], "2007"))


### PR DESCRIPTION
## Description

Exclude new IMG_VCDUCTR  from col comparison.  We could create this in mica in a new PR but it seems OK to just exclude and have tests pass for now.

This also removes the exception for END_INTEG_TIME, as with https://github.com/sot/chandra_aca/pull/180 that value should just match.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Lets tests pass if chandra_aca  has https://github.com/sot/chandra_aca/pull/180

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
ska3-flight-latest) LMABIUS-L1:mica jean$ cd ~/git/chandra_aca
(ska3-flight-latest) LMABIUS-L1:chandra_aca jean$ git rev-parse HEAD
00cc34738bebcd6b94f4e8bb999646bf9636351d
(ska3-flight-latest) LMABIUS-L1:chandra_aca jean$ cd ~/git/mica
(ska3-flight-latest) LMABIUS-L1:mica jean$ git rev-parse HEAD
40cc43aed699d4c69ecb08dc86426e70d2f60209
(ska3-flight-latest) LMABIUS-L1:mica jean$ pytest
=============================================================================================== test session starts ===============================================================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 110 items                                                                                                                                                                                               

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                                                  [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                                                       [ 17%]
mica/archive/tests/test_aca_l0.py ...ss                                                                                                                                                                     [ 21%]
mica/archive/tests/test_asp_l1.py sssssss                                                                                                                                                                   [ 28%]
mica/archive/tests/test_cda.py ..............................................                                                                                                                               [ 70%]
mica/archive/tests/test_obspar.py .                                                                                                                                                                         [ 70%]
mica/report/tests/test_write_report.py s                                                                                                                                                                    [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                                                                [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                                                      [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                                                   [ 91%]
mica/vv/tests/test_vv.py sssssssss                                                                                                                                                                          [100%]

================================================================================================ warnings summary =================================================================================================
mica/mica/archive/tests/test_cda.py: 13 warnings
mica/mica/stats/tests/test_acq_stats.py: 9 warnings
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/tables/table.py:1513: DeprecationWarning: `sometrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `any` instead.
    coords = [p.nrow for p in

mica/mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

mica/mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================================== 91 passed, 19 skipped, 24 warnings in 24.52s
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
