### PR TITLE
Unmask aca image data columns (from get_aca_images) except for IMG

### DIFF
--- a/mica/archive/aca_l0.py
+++ b/mica/archive/aca_l0.py
@@ -225,6 +225,14 @@ def get_aca_images(
         ok = slot_data_raw["QUALITY"] == 0
         slot_data = Table(slot_data_raw[ok])
 
+        # Unmask everything that can be unmasked
+        # Remove mask from columns where no values are masked. IMGRAW is excepted because
+        # the mask reflects the presence of 4x4 or 6x6 images, not entirely missing data
+        # per row.
+        for col in slot_data.itercols():
+            if not np.any(col.mask) and col.name != "IMGRAW":
+                slot_data[col.name] = col.data.data
+
         # Add slot number if there are any rows (if statement not needed after
         # https://github.com/astropy/astropy/pull/17102).
         # if len(slot_data) > 0:


### PR DESCRIPTION
## Description

Unmask slot data columns as possible.

The intent is that this is the mica equivalent of 
https://github.com/sot/chandra_aca/pull/182

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
astropy Tables from mica.archive.aca_l0.get_aca_images will have masks only on columns with missing data (except for IMG).  IMGRAW is renamed IMG within the routine, so the actual unmasking excepts IMGRAW.


## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-latest) flame:mica jean$ git rev-parse HEAD
5cf7011b866178f1f56e15dc12082ae4f16e96dd
(ska3-flight-latest) flame:mica jean$ pytest
===================================================================================== test session starts =====================================================================================
platform darwin -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
PyQt5 5.15.9 -- Qt runtime 5.15.8 -- Qt compiled 5.15.8
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: astropy-0.11.0, qt-4.4.0, cov-5.0.0, timeout-2.2.0, remotedata-0.4.1, anyio-4.3.0, filter-subpackage-0.2.0, doctestplus-1.2.1, astropy-header-0.2.2, hypothesis-6.112.0, arraydiff-0.6.1, mock-3.14.0
collected 110 items                                                                                                                                                                           

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                              [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                                   [ 17%]
mica/archive/tests/test_aca_l0.py ...ss                                                                                                                                                 [ 21%]
mica/archive/tests/test_asp_l1.py sssssss                                                                                                                                               [ 28%]
mica/archive/tests/test_cda.py ..............................................                                                                                                           [ 70%]
mica/archive/tests/test_obspar.py .                                                                                                                                                     [ 70%]
mica/report/tests/test_write_report.py s                                                                                                                                                [ 71%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                                            [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                                  [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                               [ 91%]
mica/vv/tests/test_vv.py sssssssss                                                                                                                                                      [100%]

====================================================================================== warnings summary =======================================================================================
mica/mica/archive/tests/test_cda.py: 13 warnings
mica/mica/stats/tests/test_acq_stats.py: 9 warnings
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/tables/table.py:1513: DeprecationWarning: `sometrue` is deprecated as of NumPy 1.25.0, and will be removed in NumPy 2.0. Please use `any` instead.
    coords = [p.nrow for p in

mica/mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

mica/mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range
  /Users/jean/miniforge3/envs/ska3-flight-latest/lib/python3.11/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== 91 passed, 19 skipped, 24 warnings in 36.35s
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
