### PR TITLE
Change report target_summary method to return dict or None

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -231,6 +231,19 @@ def get_obs_temps(obsid):
 
 
 def target_summary(obsid):
+    """
+    Get the target info and proposal number from the axafocat database.
+
+    Parameters
+    ----------
+    obsid : int
+
+    Returns
+    -------
+    dict or None
+        A dictionary with the target info from the axafocat.target table
+        or None if the obsid is not found.
+    """
     with Sqsh(
         dbi="sybase", server="sqlsao", user="aca_ops", database="axafocat"
     ) as ocat_db:

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -245,7 +245,20 @@ def target_summary(obsid):
                 """select * from target where
                                     target.obsid = {}""".format(obsid)
             )
-    return ocat_info
+
+    if ocat_info:
+        # Convert the masked array to a dictionary with None for masked values
+        ocat_info = Table(ocat_info, masked=True)
+        ocat = {}
+        for col in ocat_info.colnames:
+            # if the value isn't masked, put it in the dictionary
+            if not ocat_info[col].mask:
+                ocat[col] = ocat_info[col].data[0]
+            else:
+                ocat[col] = None
+        return ocat
+    else:
+        return None
 
 
 def guess_shortterm(mp_dir):

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -593,14 +593,14 @@ def main(obsid):
     if summary is not None:
         if summary["lts_lt_plan"] is not None:
             report_status["long_term"] = summary["lts_lt_plan"]
-        if summary["soe_st_sched_date"]:
+        if summary["soe_st_sched_date"] is not None:
             report_status["short_term"] = summary["soe_st_sched_date"]
 
     last_sched = ""
     if not er:
-        if summary["lts_lt_plan"]:
+        if summary["lts_lt_plan"] is not None:
             last_sched = "in LTS for {}".format(str(summary["lts_lt_plan"]))
-        if summary["soe_st_sched_date"]:
+        if summary["soe_st_sched_date"] is not None:
             last_sched = "in ST sched for {}".format(str(summary["soe_st_sched_date"]))
 
     ## Starcheck

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -259,19 +259,14 @@ def target_summary(obsid):
                                     target.obsid = {}""".format(obsid)
             )
 
-    if ocat_info:
-        # Convert the masked array to a dictionary with None for masked values
-        ocat_info = Table(ocat_info, masked=True)
-        ocat = {}
-        for col in ocat_info.colnames:
-            # if the value isn't masked, put it in the dictionary
-            if not ocat_info[col].mask:
-                ocat[col] = ocat_info[col].data[0]
-            else:
-                ocat[col] = None
-        return ocat
-    else:
-        return None
+    if ocat_info is not None:
+        # ocat_info is an astropy table Row object, so convert it to a dictionary and
+        # replace numpy masked values with None.
+        ocat_info = dict(ocat_info)
+        for key in ocat_info:
+            if ocat_info[key] is np.ma.masked:
+                ocat_info[key] = None
+    return ocat_info
 
 
 def guess_shortterm(mp_dir):

--- a/mica/report/tests/test_report.py
+++ b/mica/report/tests/test_report.py
@@ -1,0 +1,24 @@
+import mica.report.report
+
+
+def test_target_summary_or():
+    """
+    Test the target_summary method for an OR.
+
+    This test is for obsid 2121 which is quite historical at this point and should
+    not change."""
+    obsid = 2121
+    summary = mica.report.report.target_summary(obsid)
+    assert summary is not None
+    assert isinstance(summary, dict)
+    assert summary["prop_num"] == 2700413
+    assert summary["lts_lt_plan"] is None
+    assert summary["soe_st_sched_date"] == "Nov 14 2000 12:49AM"
+
+def test_target_summary_er():
+    """
+    Test that target_summary for an ER obsid returns None"""
+    obsid = 54000
+    summary = mica.report.report.target_summary(obsid)
+    assert summary is None
+

--- a/mica/report/tests/test_report.py
+++ b/mica/report/tests/test_report.py
@@ -15,10 +15,10 @@ def test_target_summary_or():
     assert summary["lts_lt_plan"] is None
     assert summary["soe_st_sched_date"] == "Nov 14 2000 12:49AM"
 
+
 def test_target_summary_er():
     """
     Test that target_summary for an ER obsid returns None"""
     obsid = 54000
     summary = mica.report.report.target_summary(obsid)
     assert summary is None
-

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -373,11 +373,11 @@ def calc_gui_stats(data):
         deltas = {"dy": dy, "dz": dz, "dr": dr}
         stats["dr_5th"] = np.percentile(deltas["dr"], 5)
         stats["dr_95th"] = np.percentile(deltas["dr"], 95)
-        for ax in deltas:
-            stats["{}_mean".format(ax)] = np.mean(deltas[ax])
-            stats["{}_std".format(ax)] = np.std(deltas[ax])
-            stats["{}_max".format(ax)] = np.max(deltas[ax])
-            stats["{}_min".format(ax)] = np.min(deltas[ax])
+        for ax, delta in deltas.items():
+            stats["{}_mean".format(ax)] = np.mean(delta)
+            stats["{}_std".format(ax)] = np.std(delta)
+            stats["{}_max".format(ax)] = np.max(delta)
+            stats["{}_min".format(ax)] = np.min(delta)
         mag = kal["AOACMAG{}".format(slot)]
         stats["aoacmag_min"] = np.min(mag)
         stats["aoacmag_mean"] = np.mean(mag)

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -982,9 +982,9 @@ class AspectInterval(object):
                 "roll_raw": "roll",
                 "q_att_raw": "q_att",
             }
-            for col in colmap:
-                asol.remove_column(colmap[col])
-                asol.rename_column(col, colmap[col])
+            for col, cmap in colmap.items():
+                asol.remove_column(cmap)
+                asol.rename_column(col, cmap)
         # Add code to handle first processing of 16091 with
         # non-confirming asol file
         if "dtheta" not in asol.dtype.names and "DTHETA" in asol.dtype.names:


### PR DESCRIPTION
## Description

Change report target_summary method to return unmasked dict or None

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes an issue that downstream code in the reporting was expecting either None or values None, not masked values.  This PR is a residual fix from the transition to using Sqsh for the database information.  It is a separate question if Sqsh.fetch_one should really return a dictionary with possible None values instead of an astropy table Row with masked values.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
This changes the interface of mica.report.report.target_summary method, which looks to only be used internally.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
 jeanconn-fido> git rev-parse HEAD
b50a7bb8218db72b2d06151446065c932cebaf89
 jeanconn-fido> pytest
=============================================================== test session starts ================================================================
platform linux -- Python 3.11.8, pytest-8.0.2, pluggy-1.4.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.2.0, anyio-4.3.0
collected 112 items                                                                                                                                

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                   [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                        [ 16%]
mica/archive/tests/test_aca_l0.py .....                                                                                                      [ 21%]
mica/archive/tests/test_asp_l1.py .......                                                                                                    [ 27%]
mica/archive/tests/test_cda.py ..............................................                                                                [ 68%]
mica/archive/tests/test_obspar.py .                                                                                                          [ 69%]
mica/report/tests/test_report.py ..                                                                                                          [ 71%]
mica/report/tests/test_write_report.py .                                                                                                     [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                 [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                       [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                                    [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                           [100%]

========================================================= 112 passed in 544.27s (0:09:04
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Two new trivial unit tests have been added.

"Live" functional testing on the obsids that showed the problem - master
```
In [1]: import mica.report.report

In [2]: mica.report.report.main(30270)
Making report for 30270
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[2], line 1
----> 1 mica.report.report.main(30270)

File /proj/sot/ska/jeanproj/git/mica/mica/report/report.py:571, in main(obsid)
    569         raise ValueError("Obsid not found in target table")
    570     report_status["ocat"] = summary["status"]
--> 571     links = obs_links(obsid, summary["seq_nbr"], summary["lts_lt_plan"])
    573 if not er and (summary["status"] in ["canceled", "unobserved", "untriggered"]):
    574     logger.debug(
    575         "Obsid {obsid} has status {status}".format(
    576             obsid=obsid, status=summary["status"]
    577         )
    578     )

File /proj/sot/ska/jeanproj/git/mica/mica/report/report.py:354, in obs_links(obsid, sequence, plan)
    351 # if this is a science observation, only try to get a star catalog if it has a home
    352 # in the schedule either in the past or the near future
    353 if plan is not None:
--> 354     plan_date = Time(datetime.datetime.strptime(plan, "%b %d %Y %I:%M%p"))
    355     if plan_date < Time.now() + 21 * u.day:
    356         mp_dir, status, mp_date = starcheck.get_mp_dir(obsid)

TypeError: strptime() argument 1 must be str, not MaskedConstant
```
This PR
```
In [1]: import mica.report.report

In [2]: mica.report.report.main(30270)
Making report for 30270
Generating V&V for obsid 30270
No V&V available
Writing out full report to /proj/sot/ska/data/mica/archive/report/webreports/30/30270/index.html
```


