### PR TITLE
replace uses of pformat_all with pformat

### DIFF
--- a/mica/archive/tests/test_asp_l1.py
+++ b/mica/archive/tests/test_asp_l1.py
@@ -102,7 +102,7 @@ def test_update_l1_archive(tmp_path):
             "content",
             "revision",
             "obsid",
-        ].pformat_all() == (
+        ].pformat() == (
             [
                 "             filename             filetime ascdsver caldbver  content   revision obsid",
                 "--------------------------------- -------- -------- -------- ---------- -------- -----",


### PR DESCRIPTION
## Description

This is a change intended for skare3 > 2025.0, where we will use astropy 7.0. It replaces uses of `Table.pformat_all()` wih `Table.pformat()`. This silences a warning.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] Linux on HEAD
```
(ska3-flight-2025.0rc4) jgonzale mica $ pytest mica
============================================================= test session starts =============================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jgonzalez/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 112 items                                                                                                                           

mica/archive/tests/test_aca_dark_cal.py ..................                                                                              [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                   [ 16%]
mica/archive/tests/test_aca_l0.py .....                                                                                                 [ 21%]
mica/archive/tests/test_asp_l1.py .......                                                                                               [ 27%]
mica/archive/tests/test_cda.py ..............................................                                                           [ 68%]
mica/archive/tests/test_obspar.py .                                                                                                     [ 69%]
mica/report/tests/test_report.py ..                                                                                                     [ 71%]
mica/report/tests/test_write_report.py .                                                                                                [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                            [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                  [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                               [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                      [100%]

============================================================== warnings summary ===============================================================
mica/mica/archive/tests/test_asp_l1.py::test_update_l1_archive
  /export/jgonzale/miniconda3/envs/ska3-flight-2025.0rc4/lib/python3.12/pty.py:95: DeprecationWarning: This process (pid=847204) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /export/jgonzale/miniconda3/envs/ska3-flight-2025.0rc4/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 112 passed, 5 warnings in 405.72s (0:06:45) =================================================
(ska3-flight-2025.0rc4) jgonzale mica $ git rev-parse --short HEAD    
75896d7
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
