### PR TITLE
Use different alg for two_byte_sum that fixes off-by-one error

### DIFF
--- a/mica/archive/aca_dark/dark_cal.py
+++ b/mica/archive/aca_dark/dark_cal.py
@@ -141,7 +141,7 @@ def _get_dark_cal_id_scalar(date, select="before", dark_cal_ids=None):
     if ii < 0:
         earliest = CxoTime(dark_cal_secs[0]).date[:8]
         raise MissingDataError(
-            f"No dark cal found before {earliest}" f"(requested dark cal on {date})"
+            f"No dark cal found before {earliest}(requested dark cal on {date})"
         )
 
     try:

--- a/mica/archive/aca_hdr3.py
+++ b/mica/archive/aca_hdr3.py
@@ -24,11 +24,19 @@ from mica.common import MissingDataError
 
 def two_byte_sum(byte_msids, scale=1):
     def func(slot_data):
-        return (
-            (slot_data[byte_msids[0]].astype("int") >> 7) * (-1 * 65535)
-            + (slot_data[byte_msids[0]].astype("int") << 8)
-            + (slot_data[byte_msids[1]].astype("int"))
-        ) * scale
+        # For each pair bytes0[i], bytes1[i], return the 16-bit signed integer
+        # corresponding to those two bytes. The input bytes are unsigned.
+        bytes0 = slot_data[byte_msids[0]]
+        bytes1 = slot_data[byte_msids[1]]
+
+        # Make a 2xN array, then transpose to Nx2, then flatten to 2N, then copy to
+        # get values continous in memory.
+        bytes = np.array([bytes0, bytes1], dtype=np.uint8).transpose().flatten().copy()
+
+        # Now view the 2N bytes as N 16-bit signed integers.
+        out = bytes.view(">i2") * scale
+
+        return out
 
     return func
 

--- a/mica/archive/aca_hdr3.py
+++ b/mica/archive/aca_hdr3.py
@@ -23,20 +23,21 @@ from mica.common import MissingDataError
 
 
 def two_byte_sum(byte_msids, scale=1):
-    def func(slot_data):
+    def func(slot_data) -> np.ma.MaskedArray:
         # For each pair bytes0[i], bytes1[i], return the 16-bit signed integer
         # corresponding to those two bytes. The input bytes are unsigned.
-        bytes0 = slot_data[byte_msids[0]]
-        bytes1 = slot_data[byte_msids[1]]
+        bytes0 = slot_data[byte_msids[0]].astype(np.uint8)
+        bytes1 = slot_data[byte_msids[1]].astype(np.uint8)
 
         # Make a 2xN array, then transpose to Nx2, then flatten to 2N, then copy to
         # get values continous in memory.
-        bytes = np.array([bytes0, bytes1], dtype=np.uint8).transpose().flatten().copy()
+        bytes8_2xN = np.ma.vstack([bytes0, bytes1], dtype=np.uint8)
+        bytes8 = bytes8_2xN.transpose().flatten().copy()
 
         # Now view the 2N bytes as N 16-bit signed integers.
-        out = bytes.view(">i2") * scale
+        ints16 = np.ma.array(bytes8.data.view(">i2"), mask=bytes8.mask[::2])
 
-        return out
+        return ints16 * scale
 
     return func
 

--- a/mica/archive/cda/services.py
+++ b/mica/archive/cda/services.py
@@ -430,8 +430,7 @@ def _get_cda_service_text(service, timeout=60, **params):
 
     if not resp.ok:
         raise RuntimeError(
-            f"got error {resp.status_code} for {resp.url}\n"
-            f"{html_to_text(resp.text)}"
+            f"got error {resp.status_code} for {resp.url}\n{html_to_text(resp.text)}"
         )
 
     return resp.text
@@ -630,7 +629,7 @@ def get_ocat_local(
         # accurate enough for this application.
         where = (
             f"arccos(sin({ra * d2r})*sin(ra*{d2r}) + "
-            f"cos({ra * d2r})*cos(ra*{d2r})*cos({dec*d2r}-dec*{d2r}))"
+            f"cos({ra * d2r})*cos(ra*{d2r})*cos({dec * d2r}-dec*{d2r}))"
             f"< {radius / 60 * d2r}"
         )
         where_parts.append(where)

--- a/mica/archive/tests/test_aca_hdr3.py
+++ b/mica/archive/tests/test_aca_hdr3.py
@@ -7,6 +7,7 @@ import os
 
 import numpy as np
 import pytest
+from astropy.table import Table
 
 from mica.archive import aca_hdr3
 
@@ -80,8 +81,7 @@ def test_two_byte_sum():
     assert np.all(out1 == np.ma.array([0, -4080, 4080, 0, 0], mask=[0, 0, 0, 0, 1]))
 
     # New code in PR #315
-    bytes8_2xN = np.ma.vstack([bytes0, bytes1], dtype=np.uint8)
-    bytes8 = bytes8_2xN.transpose().flatten().copy()
-    ints16 = np.ma.array(bytes8.data.view(">i2"), mask=bytes8.mask[::2])
+    slot_data = Table([bytes0, bytes1], names=["byte0", "byte1"])
+    ints16 = aca_hdr3.two_byte_sum(["byte0", "byte1"])(slot_data)
 
     assert np.all(ints16 == np.ma.array([0, -4081, 4080, -1, 0], mask=[0, 0, 0, 0, 1]))

--- a/mica/centroid_dashboard.py
+++ b/mica/centroid_dashboard.py
@@ -1182,7 +1182,7 @@ Next Observation
 
     for row in t_slot:
         string += f"""<tr>
-<td align='right'>{row['slot']}</td>
+<td align='right'>{row["slot"]}</td>
 """
         if row["id"] < 100:
             id_ = ""
@@ -1193,13 +1193,13 @@ Next Observation
             )
 
         string += f"""<td align='right'>{id_}</td>
-<td align='right'>{row['type']}</td>
-<td align='right'>{row['mag']}</td>
-<td align='right'>{row['yang']}</td>
-<td align='right'>{row['zang']}</td>
-<td align='right'>{row['median_mag']:.3f}</td>
-<td align='right'>{row['median_dy']:.2f}</td>
-<td align='right'>{row['median_dz']:.2f}</td>
+<td align='right'>{row["type"]}</td>
+<td align='right'>{row["mag"]}</td>
+<td align='right'>{row["yang"]}</td>
+<td align='right'>{row["zang"]}</td>
+<td align='right'>{row["median_mag"]:.3f}</td>
+<td align='right'>{row["median_dy"]:.2f}</td>
+<td align='right'>{row["median_dz"]:.2f}</td>
 </tr>
 """
     string += f"""</table>

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -920,9 +920,9 @@ def save_state_in_db(obsid, notes):
     del notes["last_sched"]
 
     idcheck = db.fetchone(
-        "select * from report_proc "
-        "where obsid = '{}' "
-        "and report_version = '{}'".format(obsid, REPORT_VERSION)
+        "select * from report_proc where obsid = '{}' and report_version = '{}'".format(
+            obsid, REPORT_VERSION
+        )
     )
 
     if idcheck is None:

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -126,8 +126,7 @@ def get_options():
     parser.add_argument(
         "--email",
         action="append",
-        help="email warning recipient, specify multiple times "
-        "for multiple recipients",
+        help="email warning recipient, specify multiple times for multiple recipients",
     )
     opt = parser.parse_args()
     return opt

--- a/mica/vv/process.py
+++ b/mica/vv/process.py
@@ -158,7 +158,7 @@ def update(obsids=None):
                 logger.warn(f"Skipping obs:ver {obsid}:{obs['revision']}. Missing data")
                 continue
             update_str = f"""UPDATE aspect_1_proc set vv_complete = {VV_VERSION}
-                              where obsid = {obsid} and revision = {obs['revision']}"""
+                              where obsid = {obsid} and revision = {obs["revision"]}"""
 
             logger.info(update_str)
             with ska_dbi.DBI(dbi="sqlite", server=FILES["asp1_proc_table"]) as db:

--- a/mica/web/views.py
+++ b/mica/web/views.py
@@ -83,7 +83,7 @@ class StarHistView(BaseView, TemplateView):
                 context["gui_table"] = gui_table
                 reports_url = (
                     "https://cxc.cfa.harvard.edu/mta/ASPECT/agasc/supplement_reports/stars/"
-                    f"{int(agasc_id//1e7):03d}/{agasc_id}/index.html"
+                    f"{int(agasc_id // 1e7):03d}/{agasc_id}/index.html"
                 )
                 context["reports_url"] = reports_url
         return context

--- a/scripts/update_agasc_supplement.py
+++ b/scripts/update_agasc_supplement.py
@@ -38,8 +38,7 @@ def get_options(args=None):
         "--bad-star-source",
         type=int,
         help=(
-            "Source identifier indicating provenance (default=max "
-            "existing source + 1)"
+            "Source identifier indicating provenance (default=max existing source + 1)"
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Description

This fixes a bug in `two_byte_sum` where it is off by one for negative integers.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
None

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Mac
```
(ska3-flight-2025.0rc2) ➜  mica git:(fix-two-byte-sum) git rev-parse --short HEAD
0ade721
(ska3-flight-2025.0rc2) ➜  mica git:(fix-two-byte-sum) pytest                    
================================================================= test session starts =================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Volumes/git
configfile: pytest.ini
plugins: doctestplus-1.3.0, anyio-4.7.0, timeout-2.3.1
collected 113 items                                                                                                                                   

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                      [ 15%]
mica/archive/tests/test_aca_hdr3.py ..                                                                                                          [ 17%]
mica/archive/tests/test_aca_l0.py ...ss                                                                                                         [ 22%]
mica/archive/tests/test_asp_l1.py sssssss                                                                                                       [ 28%]
mica/archive/tests/test_cda.py ..............................................                                                                   [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                             [ 69%]
mica/report/tests/test_report.py ss                                                                                                             [ 71%]
mica/report/tests/test_write_report.py s                                                                                                        [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                    [ 85%]
mica/stats/tests/test_acq_stats.py .ss                                                                                                          [ 88%]
mica/stats/tests/test_guide_stats.py .sss                                                                                                       [ 92%]
mica/vv/tests/test_vv.py sssssssss                                                                                                              [100%]

=========================================================== 87 passed, 26 skipped in 23.38s ===========================================================
```

Independent check of unit tests by Jean
- [x] Linux (with relatively uncontaminated ska3-masters)
```
(test) jeanconn-fido> pytest
==================================================================================== test session starts ====================================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 113 items                                                                                                                                                                         

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                            [ 15%]
mica/archive/tests/test_aca_hdr3.py ..                                                                                                                                                [ 17%]
mica/archive/tests/test_aca_l0.py .....                                                                                                                                               [ 22%]
mica/archive/tests/test_asp_l1.py .......                                                                                                                                             [ 28%]
mica/archive/tests/test_cda.py ..............................................                                                                                                         [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                                                   [ 69%]
mica/report/tests/test_report.py ..                                                                                                                                                   [ 71%]
mica/report/tests/test_write_report.py .                                                                                                                                              [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                                          [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                                [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                             [ 92%]
mica/vv/tests/test_vv.py .........                                                                                                                                                    [100%]

===================================================================================== warnings summary ======================================================================================
mica/mica/archive/tests/test_asp_l1.py::test_update_l1_archive
  /fido.real/miniforge3/envs/test/lib/python3.12/pty.py:95: DeprecationWarning: This process (pid=219487) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /fido.real/miniforge3/envs/test/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== 113 passed, 5 warnings in 546.98s (0:09:06)
(test) jeanconn-fido> git rev-parse HEAD
812d3f079115c5601bb9ebd39123985085cb9f52
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
This looks right.
```
from mica.archive import aca_hdr3
from ska_matplotlib import plot_cxctime
from cheta import fetch_sci

dat_mica = aca_hdr3.MSID("ccd_temp", "2012:004:12:00:00", "2012:005:12:00:00")
dat_fetch = fetch_sci.Msid("aacccdpt", "2012:004:12:00:00", "2012:005:12:00:00")

plot_cxctime(dat_fetch.times, dat_fetch.vals)
plot_cxctime(dat_mica.times, dat_mica.vals)
```
<img width="478" alt="image" src="https://github.com/user-attachments/assets/9652c83a-b617-412c-8545-c79cb2e779b2" />

As a reviewer I, Jean, also just looked at this and this makes sense to me to appropriately cover the range of signed 16 bit ints with the new code.
```
In [17]: bytes0 = [128, 127]

In [18]: bytes1 = [0, 255]

In [19]: slot_data = Table([bytes0, bytes1], names=['bytes0', 'bytes1'])

In [20]: aca_hdr3.two_byte_sum(["bytes0", "bytes1"])(slot_data)
Out[20]: 
masked_array(data=[-32768, 32767],
             mask=[False, False],
       fill_value=999999,
            dtype=int16)
```
The previous code/output just didn't succeed in covering the range.
```
In [8]: aca_hdr3.two_byte_sum(["bytes0", "bytes1"])(slot_data)
Out[8]: 
<Column name='bytes0' dtype='int64' length=2>
-32767
 32767
```
