### PR TITLE
skip test_report.py::test_target_summary_or/er

### DIFF
--- a/mica/report/tests/test_report.py
+++ b/mica/report/tests/test_report.py
@@ -1,6 +1,24 @@
+import getpass
+import pytest
+
 import mica.report.report
 
+user = getpass.getuser()
 
+try:
+    import ska_dbi.sqsh
+
+    with ska_dbi.sqsh.Sqsh(
+        server="sqlsao", dbi="sybase", user=user, database="axafvv"
+    ) as db:
+        HAS_SYBASE_ACCESS = True
+except Exception as e:
+    HAS_SYBASE_ACCESS = False
+
+
+@pytest.mark.skipif(
+    "not HAS_SYBASE_ACCESS", reason="Report test requires Sybase VV access"
+)
 def test_target_summary_or():
     """
     Test the target_summary method for an OR.
@@ -16,6 +34,9 @@ def test_target_summary_or():
     assert summary["soe_st_sched_date"] == "Nov 14 2000 12:49AM"
 
 
+@pytest.mark.skipif(
+    "not HAS_SYBASE_ACCESS", reason="Report test requires Sybase VV access"
+)
 def test_target_summary_er():
     """
     Test that target_summary for an ER obsid returns None"""

--- a/mica/report/tests/test_report.py
+++ b/mica/report/tests/test_report.py
@@ -1,4 +1,5 @@
 import getpass
+
 import pytest
 
 import mica.report.report
@@ -12,7 +13,7 @@ try:
         server="sqlsao", dbi="sybase", user=user, database="axafvv"
     ) as db:
         HAS_SYBASE_ACCESS = True
-except Exception as e:
+except Exception:
     HAS_SYBASE_ACCESS = False
 
 


### PR DESCRIPTION
This PR makes changes to skip test_report.py::test_target_summary_or/er if sybase is not available.

## Description

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue that the target summary tests don't work on systems without Sybase/Sqsh access.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->


Independent check of unit tests by Jean
- [x] Mac
```
Switched to a new branch 'skip-test-report'
(2025.0) flame:mica jean$ pytest
============================================================================== test session starts ==============================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/jean/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 112 items                                                                                                                                                             

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                     [ 16%]
mica/archive/tests/test_aca_l0.py ...ss                                                                                                                                   [ 21%]
mica/archive/tests/test_asp_l1.py sssssss                                                                                                                                 [ 27%]
mica/archive/tests/test_cda.py ..............................................                                                                                             [ 68%]
mica/archive/tests/test_obspar.py .                                                                                                                                       [ 69%]
mica/report/tests/test_report.py ss                                                                                                                                       [ 71%]
mica/report/tests/test_write_report.py s                                                                                                                                  [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                              [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                    [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                 [ 91%]
mica/vv/tests/test_vv.py sssssssss                                                                                                                                        [100%]

=============================================================================== warnings summary ================================================================================
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range
mica/mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range
  /Users/jean/miniforge3/envs/2025.0/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

mica/mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range
  /Users/jean/miniforge3/envs/2025.0/lib/python3.12/site-packages/django/utils/encoding.py:266: DeprecationWarning: 'locale.getdefaultlocale' is deprecated and slated for removal in Python 3.15. Use setlocale(), getencoding() and getlocale() instead.
    encoding = locale.getdefaultlocale()[1] or 'ascii'

mica/mica/starcheck/tests/test_catalog_fetches.py::test_validate_catalogs_over_range
  /Users/jean/miniforge3/envs/2025.0/lib/python3.12/site-packages/django/http/request.py:1: DeprecationWarning: 'cgi' is deprecated and slated for removal in Python 3.13
    import cgi

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================================== 91 passed, 21 skipped, 6 warnings in 28.41s ==================================================================
(2025.0) flame:mica jean$ git rev-parse HEAD
53c85a09a12847ec0090dedd73294aa56ee18442
```

- [x] Linux
This PR requires 2025.x because it is based on the pformat PR, that's fine.  But I also had other mica tests fails on linux when I ran this.  Those weren't the tests in this PR so I'm OK with that 
```
(ska3-flight-2025.0rc2) jeanconn-fido> pytest
====================================================================================== test session starts ======================================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 112 items                                                                                                                                                                             

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                                                                [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                                                                     [ 16%]
mica/archive/tests/test_aca_l0.py .....                                                                                                                                                   [ 21%]
mica/archive/tests/test_asp_l1.py .....F.                                                                                                                                                 [ 27%]
mica/archive/tests/test_cda.py ..............................................                                                                                                             [ 68%]
mica/archive/tests/test_obspar.py .                                                                                                                                                       [ 69%]
mica/report/tests/test_report.py ..                                                                                                                                                       [ 71%]
mica/report/tests/test_write_report.py F                                                                                                                                                  [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                                                              [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                                                    [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                                                                                 [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                                                                        [100%]

=========================================================================================== FAILURES ============================================================================================
____________________________________________________________________________________ test_update_l1_archive _____________________________________________________________________________________

tmp_path = PosixPath('/tmp/pytest-of-jeanconn/pytest-10770/test_update_l1_archive0')

    @pytest.mark.skipif("not test_helper.on_head_network()", reason="Not on HEAD network")
    def test_update_l1_archive(tmp_path):
        config = asp_l1.CONFIG.copy()
        config["data_root"] = tmp_path / "asp1"
        config["temp_root"] = tmp_path / "temp"
        config["bad_obsids"] = tmp_path / "asp1" / "asp_l1_bad_obsids.dat"
        config["firstrun"] = True
        config["rebuild"] = True
        config["obsid"] = 1
        config["version"] = 4
        archive = obsid_archive.ObsArchive(config)
>       obsids = archive.update()  # noqa: F841 assigned but not used

mica/archive/tests/test_asp_l1.py:92: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
mica/archive/obsid_archive.py:664: in update
    self.set_env()
mica/archive/obsid_archive.py:127: in set_env
    self._arc5 = Ska.arc5gl.Arc5gl()
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/Ska/arc5gl/arc5gl.py:45: in __init__
    self.arc5gl.expect(self.prompt)
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/pexpect/spawnbase.py:354: in expect
    return self.expect_list(compiled_pattern_list,
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/pexpect/spawnbase.py:383: in expect_list
    return exp.expect_loop(timeout)
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/pexpect/expect.py:179: in expect_loop
    return self.eof(e)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <pexpect.expect.Expecter object at 0x7ff866eb0290>, err = EOF('End Of File (EOF). Exception style platform.')

    def eof(self, err=None):
        spawn = self.spawn
    
        spawn.before = spawn._before.getvalue()
        spawn._buffer = spawn.buffer_type()
        spawn._before = spawn.buffer_type()
        spawn.after = EOF
        index = self.searcher.eof_index
        if index >= 0:
            spawn.match = EOF
            spawn.match_index = index
            return index
        else:
            spawn.match = None
            spawn.match_index = None
            msg = str(spawn)
            msg += '\nsearcher: %s' % self.searcher
            if err is not None:
                msg = str(err) + '\n' + msg
    
            exc = EOF(msg)
            exc.__cause__ = None # in Python 3.x we can use "raise exc from None"
>           raise exc
E           pexpect.exceptions.EOF: End Of File (EOF). Exception style platform.
E           <pexpect.pty_spawn.spawn object at 0x7ff866eb0980>
E           command: /fido.real/miniforge3/envs/ska3-flight-2025.0rc2/bin/arc5gl
E           args: [b'/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/bin/arc5gl', b'--stdin']
E           buffer (last 100 chars): ''
E           before (last 100 chars): 'rl/App/Env.pm line 296.\r\n at /fido.real/miniforge3/envs/ska3-flight-2025.0rc2/bin/arc5gl line 779.\r\n'
E           after: <class 'pexpect.exceptions.EOF'>
E           match: None
E           match_index: None
E           exitstatus: None
E           flag_eof: True
E           pid: 1190997
E           child_fd: 13
E           closed: False
E           timeout: 100000
E           delimiter: <class 'pexpect.exceptions.EOF'>
E           logfile: None
E           logfile_read: None
E           logfile_send: None
E           maxread: 2000
E           ignorecase: False
E           searchwindowsize: None
E           delaybeforesend: 0.05
E           delayafterclose: 0.1
E           delayafterterminate: 0.1
E           searcher: searcher_re:
E               0: re.compile('ARC5GL> ')

/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/pexpect/expect.py:122: EOF
______________________________________________________________________________________ test_write_reports _______________________________________________________________________________________

    @pytest.mark.skipif(
        "not HAS_SYBASE_ACCESS", reason="Report test requires Sybase VV access"
    )
    @pytest.mark.skipif(
        "not HAS_SC_ARCHIVE", reason="Report test requires mica starcheck archive"
    )
    def test_write_reports():
        """
        Make a report and database
        """
        tempdir = tempfile.mkdtemp()
        # Get a temporary file, but then delete it, because report.py will only
        # make a new table if the supplied file doesn't exist
        fh, fn = tempfile.mkstemp(dir=tempdir, suffix=".db3")
        os.unlink(fn)
        report.REPORT_ROOT = tempdir
        report.REPORT_SERVER = fn
        for obsid in [20001, 15175, 54778, 44077]:
>           report.main(obsid)

mica/report/tests/test_write_report.py:51: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
mica/report/report.py:638: in main
    fig, cat, obs = catalog.plot(obsid, mp_dir)
mica/catalog/catalog.py:31: in plot
    fig = plot_stars(
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/chandra_aca/plot.py:72: in wrapper
    return func(*args, **kwargs)
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/chandra_aca/plot.py:306: in plot_stars
    fig = plt.figure(figsize=(5.325, 5.325))
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/matplotlib/pyplot.py:1027: in figure
    manager = new_figure_manager(
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/matplotlib/pyplot.py:549: in new_figure_manager
    _warn_if_gui_out_of_main_thread()
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/matplotlib/pyplot.py:526: in _warn_if_gui_out_of_main_thread
    canvas_class = cast(type[FigureCanvasBase], _get_backend_mod().FigureCanvas)
/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/matplotlib/pyplot.py:358: in _get_backend_mod
    switch_backend(rcParams._get("backend"))
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

newbackend = 'TkAgg'

    def switch_backend(newbackend: str) -> None:
        """
        Set the pyplot backend.
    
        Switching to an interactive backend is possible only if no event loop for
        another interactive backend has started.  Switching to and from
        non-interactive backends is always possible.
    
        If the new backend is different than the current backend then all open
        Figures will be closed via ``plt.close('all')``.
    
        Parameters
        ----------
        newbackend : str
            The case-insensitive name of the backend to use.
    
        """
        global _backend_mod
        # make sure the init is pulled up so we can assign to it later
        import matplotlib.backends
    
        if newbackend is rcsetup._auto_backend_sentinel:
            current_framework = cbook._get_running_interactive_framework()
    
            if (current_framework and
                    (backend := backend_registry.backend_for_gui_framework(
                        current_framework))):
                candidates = [backend]
            else:
                candidates = []
            candidates += [
                "macosx", "qtagg", "gtk4agg", "gtk3agg", "tkagg", "wxagg"]
    
            # Don't try to fallback on the cairo-based backends as they each have
            # an additional dependency (pycairo) over the agg-based backend, and
            # are of worse quality.
            for candidate in candidates:
                try:
                    switch_backend(candidate)
                except ImportError:
                    continue
                else:
                    rcParamsOrig['backend'] = candidate
                    return
            else:
                # Switching to Agg should always succeed; if it doesn't, let the
                # exception propagate out.
                switch_backend("agg")
                rcParamsOrig["backend"] = "agg"
                return
        # have to escape the switch on access logic
        old_backend = dict.__getitem__(rcParams, 'backend')
    
        module = backend_registry.load_backend_module(newbackend)
        canvas_class = module.FigureCanvas
    
        required_framework = canvas_class.required_interactive_framework
        if required_framework is not None:
            current_framework = cbook._get_running_interactive_framework()
            if (current_framework and required_framework
                    and current_framework != required_framework):
>               raise ImportError(
                    "Cannot load backend {!r} which requires the {!r} interactive "
                    "framework, as {!r} is currently running".format(
                        newbackend, required_framework, current_framework))
E               ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running

/fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/matplotlib/pyplot.py:423: ImportError
------------------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------------------
Making report for 20001
--------------------------------------------------------------------------------------- Captured log call ---------------------------------------------------------------------------------------
INFO     mica.report:report.py:562 Making report for 20001
DEBUG    urllib3.connectionpool:connectionpool.py:1049 Starting new HTTPS connection (1): docs.google.com:443
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://docs.google.com:443 "GET /spreadsheets/d/19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ/export?format=csv HTTP/1.1" 307 None
DEBUG    urllib3.connectionpool:connectionpool.py:1049 Starting new HTTPS connection (1): doc-0s-60-sheets.googleusercontent.com:443
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://doc-0s-60-sheets.googleusercontent.com:443 "GET /export/54bogvaave6cua4cdnls17ksc4/3vqspoe1j1snk88lkml26l5tk0/1736217225000/105250506097979753968/*/19d6XqBhWoFjC-z1lS1nM6wLE_zjr4GYB1lOvrEGCbKQ?format=csv HTTP/1.1" 200 None
DEBUG    urllib3.connectionpool:connectionpool.py:1049 Starting new HTTPS connection (1): occweb.cfa.harvard.edu:443
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://occweb.cfa.harvard.edu:443 "GET /occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS/2024/DEC HTTP/1.1" 301 None
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://occweb.cfa.harvard.edu:443 "GET /occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS/2024/DEC/ HTTP/1.1" 200 None
DEBUG    urllib3.connectionpool:connectionpool.py:1049 Starting new HTTPS connection (1): occweb.cfa.harvard.edu:443
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://occweb.cfa.harvard.edu:443 "GET /occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS/2025/JAN HTTP/1.1" 301 None
DEBUG    urllib3.connectionpool:connectionpool.py:544 https://occweb.cfa.harvard.edu:443 "GET /occweb/FOT/mission_planning/PRODUCTS/APPR_LOADS/2025/JAN/ HTTP/1.1" 200 None
======================================================================================= warnings summary ========================================================================================
mica/mica/archive/tests/test_asp_l1.py::test_update_l1_archive
  /fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/pty.py:95: DeprecationWarning: This process (pid=1190855) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================================================== short test summary info ====================================================================================
FAILED mica/archive/tests/test_asp_l1.py::test_update_l1_archive - pexpect.exceptions.EOF: End Of File (EOF). Exception style platform.
FAILED mica/report/tests/test_write_report.py::test_write_reports - ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running
===================================================================== 2 failed, 110 passed, 5 warnings in 486.25s (0:08:06)
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
