### PR TITLE
Set mica.report.report.main matplotlib backend to Agg

### DIFF
--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -558,7 +558,7 @@ def main(obsid):
 
     # Set the backend (used for the catalog plot).
     # mica.report is intended to be non-interactive so Agg is fine.
-    matplotlib.use('Agg')
+    matplotlib.use("Agg")
 
     jinja_env = jinja2.Environment(loader=jinja2.PackageLoader("mica.report"))
     jinja_env.line_comment_prefix = "##"

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -640,7 +640,6 @@ def main(obsid):
             raise LookupError("Observation has no pointing.")
         if len(obs_sc["cat"]) == 0:
             raise LookupError("Observation has no catalog")
-
         fig, cat, obs = catalog.plot(obsid, mp_dir)
         sc = starcheck.get_starcheck_catalog(obsid, mp_dir)
         fig.savefig(os.path.join(outdir, "starcheck.png"))

--- a/mica/report/report.py
+++ b/mica/report/report.py
@@ -14,6 +14,7 @@ from pathlib import Path
 import agasc
 import astropy.units as u
 import jinja2
+import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
 import ska_dbi
@@ -555,6 +556,10 @@ def main(obsid):
     if not os.path.exists(outdir):
         os.makedirs(outdir)
 
+    # Set the backend (used for the catalog plot).
+    # mica.report is intended to be non-interactive so Agg is fine.
+    matplotlib.use('Agg')
+
     jinja_env = jinja2.Environment(loader=jinja2.PackageLoader("mica.report"))
     jinja_env.line_comment_prefix = "##"
     jinja_env.line_statement_prefix = "#"
@@ -635,6 +640,7 @@ def main(obsid):
             raise LookupError("Observation has no pointing.")
         if len(obs_sc["cat"]) == 0:
             raise LookupError("Observation has no catalog")
+
         fig, cat, obs = catalog.plot(obsid, mp_dir)
         sc = starcheck.get_starcheck_catalog(obsid, mp_dir)
         fig.savefig(os.path.join(outdir, "starcheck.png"))


### PR DESCRIPTION
## Description

Set the matplotlib backend to Agg in mica.report.report.main()

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This is meant to be run non-interactively.  It is generally called from scripts/update_reports.py which explicitly sets the backend to Agg, but if one needs to manually run reports, it would be a defect for it to not have the non-interactive backend set.  It also looks like for 2025.x that the test to write reports would fail trying to run with the interactive backend in a headless test env.
```
FAILED mica/report/tests/test_write_report.py::test_write_reports - ImportError: Cannot load backend 'TkAgg' which requires the 'tk' interactive framework, as 'headless' is currently running
```
I could have fixed the test by just setting the backend for the test, but it seemed a bug in general for the code to try to use the interactive backend in general to make mica html reports.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
I think this would leave the backend set as Agg for downstream code if mica.report.report.main was run before other codes as I made no attempt to put this in a closure and retain the original backend state after reports are made.  Given how the reporting is used, this seems non-impacting, but could be reevaluated if it becomes an issue.

## Testing
<!-- If relevant describe any special setup for testing. -->
Tested in 2025.0rc5 

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
jeanconn-fido> conda list ska3
# packages in environment at /fido.real/miniforge3/envs/ska3-flight-2025.0rc2:
#
# Name                    Version                   Build  Channel
ska3-core                 2025.0rc5                     0    https://icxc.cfa.harvard.edu/aspect/ska3-conda/twelve
ska3-flight               2025.0rc5                     0    https://icxc.cfa.harvard.edu/aspect/ska3-conda/twelve
ska3-perl                 2025.0rc5                     0    https://icxc.cfa.harvard.edu/aspect/ska3-conda/twelve
ska3-template             2022.06.02                    0    https://icxc.cfa.harvard.edu/aspect/ska3-conda/twelve
jeanconn-fido> git rev-parse HEAD
2567e454118f6490509eec179d98ef662155586f
jeanconn-fido> pytest
================================================================ test session starts =================================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 112 items                                                                                                                                  

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                     [ 16%]
mica/archive/tests/test_aca_hdr3.py .                                                                                                          [ 16%]
mica/archive/tests/test_aca_l0.py .....                                                                                                        [ 21%]
mica/archive/tests/test_asp_l1.py .......                                                                                                      [ 27%]
mica/archive/tests/test_cda.py ..............................................                                                                  [ 68%]
mica/archive/tests/test_obspar.py .                                                                                                            [ 69%]
mica/report/tests/test_report.py ..                                                                                                            [ 71%]
mica/report/tests/test_write_report.py .                                                                                                       [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                   [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                         [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                                      [ 91%]
mica/vv/tests/test_vv.py .........                                                                                                             [100%]

================================================================== warnings summary ==================================================================
mica/mica/archive/tests/test_asp_l1.py::test_update_l1_archive
  /fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/pty.py:95: DeprecationWarning: This process (pid=1221525) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /fido.real/miniforge3/envs/ska3-flight-2025.0rc2/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================================== 112 passed, 5 warnings in 548.96s (0:09:08)
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
