### PR TITLE
Limit stat update range to end of AOPCADMD data

### DIFF
--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -469,9 +469,14 @@ def calc_acq_stats(manvr, vals, times):
 
 
 def _get_obsids_to_update(check_missing=False):
+    # Use the end of AOPCADMD data as the end of the time range for kadi obsids
+    _, aopcadmd_end_time = fetch.get_time_range("AOPCADMD")
+
     if check_missing:
         last_tstart = "2007:271:12:00:00"
-        kadi_obsids = events.obsids.filter(start=last_tstart)
+        kadi_obsids = events.obsids.filter(
+            start=last_tstart, stop__lte=aopcadmd_end_time
+        )
         with tables.open_file(table_file, "r") as h5:
             tbl_data = h5.root.data[:]
         # get all obsids that aren't already in tbl
@@ -483,7 +488,9 @@ def _get_obsids_to_update(check_missing=False):
                 last_tstart = tbl.cols.guide_tstart[tbl.colindexes["guide_tstart"][-1]]
         except Exception:
             last_tstart = "2002:012:12:00:00"
-        kadi_obsids = events.obsids.filter(start=last_tstart)
+        kadi_obsids = events.obsids.filter(
+            start=last_tstart, stop__lte=aopcadmd_end_time
+        )
         # Skip the first obsid (as we already have it in the table)
         obsids = [o.obsid for o in kadi_obsids][1:]
     return obsids

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -478,7 +478,8 @@ def _get_obsids_to_update(check_missing=False):
     #
     # Note that the obsid event interval is the full interval of constant obsid.
     # Obsid commanding is normally in the maneuver between observations.
-    # And note that the normal stop kwarg is inclusive and applied as a filter on the start time.
+    # And note that the normal stop kwarg is inclusive and includes intervals that intersect with
+    # that stop time.
 
     if check_missing:
         last_tstart = "2007:271:12:00:00"

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -472,6 +472,14 @@ def _get_obsids_to_update(check_missing=False):
     # Use the end of AOPCADMD data as the end of the time range for kadi obsids
     _, aopcadmd_end_time = fetch.get_time_range("AOPCADMD")
 
+    # There's some duplication below in how stop time is applied, but in both
+    # cases the the kadi obsids are filtered on the stop time of the obsid as less than or equal to
+    # the end of AOPCADMD data as available from the CXC archive.
+    #
+    # Note that the obsid event interval is the full interval of constant obsid.
+    # Obsid commanding is normally in the maneuver between observations.
+    # And note that the normal stop kwarg is inclusive and applied as a filter on the start time.
+
     if check_missing:
         last_tstart = "2007:271:12:00:00"
         kadi_obsids = events.obsids.filter(

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -412,7 +412,8 @@ def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop
     #
     # Note that the obsid event interval is the full interval of constant obsid.
     # Obsid commanding is normally in the maneuver between observations.
-    # And note that the normal stop kwarg is inclusive and applied as a filter on the start time.
+    # And note that the normal stop kwarg is inclusive and includes intervals that intersect with
+    # that stop time.
 
     if check_missing:
         last_tstart = start if start is not None else "2007:271:12:00:00"

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -400,9 +400,19 @@ def calc_gui_stats(data):
 
 
 def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop=None):
-    # Use the end of AOPCADMD data or a supplied stop time
+    # Use the end of AOPCADMD data or a supplied stop time.
     _, aopcadmd_end_time = fetch.get_time_range("AOPCADMD")
     stop = stop if stop is not None else aopcadmd_end_time
+
+    # There's some duplication below in how stop time is applied, but in both
+    # cases the the kadi obsids are filtered on the stop time of the obsid as less than or equal to
+    # the stop time defined above (the supplied stop time or the end of cxc archive
+    # AOPCADMD data). The kadi obsid events may be complete past the end of
+    # the AOPCADMD data, especially if kadi events are updated using MAUDE data.
+    #
+    # Note that the obsid event interval is the full interval of constant obsid.
+    # Obsid commanding is normally in the maneuver between observations.
+    # And note that the normal stop kwarg is inclusive and applied as a filter on the start time.
 
     if check_missing:
         last_tstart = start if start is not None else "2007:271:12:00:00"

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -400,9 +400,13 @@ def calc_gui_stats(data):
 
 
 def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop=None):
+    # Use the end of AOPCADMD data or a supplied stop time
+    _, aopcadmd_end_time = fetch.get_time_range("AOPCADMD")
+    stop = stop if stop is not None else aopcadmd_end_time
+
     if check_missing:
         last_tstart = start if start is not None else "2007:271:12:00:00"
-        kadi_obsids = events.obsids.filter(start=last_tstart)
+        kadi_obsids = events.obsids.filter(start=last_tstart, stop__lte=stop)
         with tables.open_file(table_file, "r") as h5:
             tbl_data = h5.root.data[:]
         # get all obsids that aren't already in tbl
@@ -416,7 +420,7 @@ def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop
                 ]
         except Exception:
             last_tstart = start if start is not None else "2002:012:12:00:00"
-        kadi_obsids = events.obsids.filter(start=last_tstart, stop=stop)
+        kadi_obsids = events.obsids.filter(start=last_tstart, stop__lte=stop)
         # Skip the first obsid (as we already have it in the table)
         obsids = [o.obsid for o in kadi_obsids][1:]
     return obsids


### PR DESCRIPTION
## Description

Limit stat update range to end of AOPCADMD data by default.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
Fixes issue that more kadi.obsid events from https://github.com/sot/kadi/pull/343 could cause errors out of the update code.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
69ec2ba4cf5262f233110b7a379bbd0c7a49776e
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 113 items                                                            

mica/archive/tests/test_aca_dark_cal.py ..................               [ 15%]
mica/archive/tests/test_aca_hdr3.py ..                                   [ 17%]
mica/archive/tests/test_aca_l0.py .....                                  [ 22%]
mica/archive/tests/test_asp_l1.py .......                                [ 28%]
mica/archive/tests/test_cda.py ......................................... [ 64%]
.....                                                                    [ 69%]
mica/archive/tests/test_obspar.py .                                      [ 69%]
mica/report/tests/test_report.py ..                                      [ 71%]
mica/report/tests/test_write_report.py .                                 [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............             [ 85%]
mica/stats/tests/test_acq_stats.py ...                                   [ 88%]
mica/stats/tests/test_guide_stats.py ....                                [ 92%]
mica/vv/tests/test_vv.py .........                                       [100%]

=============================== warnings summary ===============================
mica/mica/archive/tests/test_asp_l1.py::test_update_l1_archive
  /proj/sot/ska3/flight/lib/python3.12/pty.py:95: DeprecationWarning: This process (pid=2840731) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /proj/sot/ska3/flight/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 113 passed, 5 warnings in 549.75s (0:09:09) ==================

```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
For functional testing, I created a ska3 test environment with the updated kadi events3.db3 file seeded with the flight versions of the acq and guide stats tables and ran masters mica status update jobs on that and then re-seeded the tables and ran this PRs update jobs on on those tables.

Unfortunately, with the data available just now, there are no errors from the masters version - I believe this is due to the fact that there is already code to not process the obsids if 1) there is no obspar available or 2) there is no complete next manvr.  So we'd need a bunch of events with obspars but no cxc aopcadmd data to hit this new filter in the new PR.

However, given the scope of this PR I think just showing that the update job processes without error using the new code is really sufficient functional testing:
```
In [1]: run /fido.real/miniforge3/envs/ska3-latest/share/mica/update_acq_stats.py
Processing obsid 29979
Found obsid manvr at 2025:082:14:11:37.737
Found dwell at 2025:082:14:49:35.800
calculating statistics
arranging stats into tabular data
saving stats to h5 table
Processing obsid 42541
Skipping obsid 42541: No manvr or dwell for 42541
Processing obsid 28111
Found obsid manvr at 2025:082:19:03:29.863
Found dwell at 2025:082:19:32:29.801
calculating statistics
arranging stats into tabular data
saving stats to h5 table
Processing obsid 28357
Found obsid manvr at 2025:082:23:17:16.240
Found dwell at 2025:082:23:55:51.202
calculating statistics
arranging stats into tabular data
saving stats to h5 table

In [2]: run /fido.real/miniforge3/envs/ska3-latest/share/mica/update_guide_stats.py
Processing obsid 29979
Found obsid manvr at 2025:082:14:11:37.737
Found dwell at 2025:082:14:49:35.800
calculating statistics
arranging stats into tabular data
saving stats to h5 table
Processing obsid 42541
Skipping obsid 42541: No manvr or dwell for 42541
Processing obsid 28111
Found obsid manvr at 2025:082:19:03:29.863
Found dwell at 2025:082:19:32:29.801
calculating statistics
arranging stats into tabular data
saving stats to h5 table
Processing obsid 28357

```
