### PR TITLE
New ruff fixes

### DIFF
--- a/mica/starcheck/process.py
+++ b/mica/starcheck/process.py
@@ -29,7 +29,7 @@ FILES = dict(data_root=os.path.join(MICA_ARCHIVE, "starcheck"), sql_def="starche
 def ingest_obs(obs, obs_idx, sc_id, st, db, existing=None):
     if existing is not None:
         existing_obs = [eobs for eobs in existing if eobs["obsid"] == int(obs["obsid"])]
-        if len(existing_obs):
+        if existing_obs:
             logger.debug("Skipping ingest of %s %d" % (st, int(obs["obsid"])))
             return
     obs_d = obs["obs"]
@@ -113,7 +113,7 @@ def get_new_starcheck_files(rootdir, mtime=0):
             prune_dirs(dirs, r"ofls[a-z]$")
         elif depth > 5:
             files = [x for x in raw_files if re.match(r"starcheck\.txt$", x)]
-            if len(files):
+            if files:
                 starchecks.append(os.path.join(root, files[0]))
             while dirs:
                 dirs.pop()

--- a/mica/vv/core.py
+++ b/mica/vv/core.py
@@ -388,12 +388,12 @@ class Obi(object):
 
         # Infer an aspect interval from each aspect solution, but
         # exclude the combined aspect solution by CONTENT type.
-        if len(asol_files):
+        if asol_files:
             for file in asol_files:
                 if pyfits.open(file)[1].header["CONTENT"] != "ASPSOLOBI":
                     self.aiids.append(self._aiid_from_asol(file, obsdir))
         ASP_dirs = sorted(glob(os.path.join(obsdir, "ASP_L1_*")))
-        if len(ASP_dirs):
+        if ASP_dirs:
             for dir in ASP_dirs:
                 max_out = max(sorted(glob(os.path.join(dir, "out*"))))
                 asol_files = sorted(glob(os.path.join(max_out, "pcad*asol*")))
@@ -438,7 +438,7 @@ class Obi(object):
                 slotval = [
                     i.deltas[slot][d] for i in self.aspect_intervals if slot in i.deltas
                 ]
-                if len(slotval):
+                if slotval:
                     if isinstance(slotval[0], np.ma.MaskedArray):
                         cslot[d] = ma.concatenate(slotval)
                     else:
@@ -1031,7 +1031,7 @@ class AspectInterval(object):
         ]
 
         # Nothing else to do if there are no missing slots
-        if not len(missing_slots):
+        if not missing_slots:
             return
 
         try:


### PR DESCRIPTION
## Description

New ruff fixes.

These are all fixing 
PLC1802 [*] `len(list)` used as condition without comparison

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-jeanconn-fido> git rev-parse HEAD
26855f42ea07928056720ae265be49868ef28c71
ska3-jeanconn-fido> pytest
============================= test session starts ==============================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 113 items                                                            

mica/archive/tests/test_aca_dark_cal.py ..................               [ 15%]
mica/archive/tests/test_aca_hdr3.py ..                                   [ 17%]
mica/archive/tests/test_aca_l0.py .....                                  [ 22%]
mica/archive/tests/test_asp_l1.py .......                                [ 28%]
mica/archive/tests/test_cda.py ......................................... [ 64%]
.....                                                                    [ 69%]
mica/archive/tests/test_obspar.py .                                      [ 69%]
mica/report/tests/test_report.py ..                                      [ 71%]
mica/report/tests/test_write_report.py .                                 [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............             [ 85%]
mica/stats/tests/test_acq_stats.py ...                                   [ 88%]
mica/stats/tests/test_guide_stats.py ....                                [ 92%]
mica/vv/tests/test_vv.py .........                                       [100%]

=============================== warnings summary ===============================
mica/mica/archive/tests/test_asp_l1.py::test_update_l1_archive
  /proj/sot/ska3/flight/lib/python3.12/pty.py:95: DeprecationWarning: This process (pid=2598697) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /proj/sot/ska3/flight/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================= 113 passed, 5 warnings in 557.89s (0:09:17) ==================
```
Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.
