### PR TITLE
Fix bug in acq/guide stats processing range

### DIFF
--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -14,6 +14,7 @@ from astropy.table import Column, Table
 from Chandra.Time import DateTime
 from chandra_aca import dark_model
 from chandra_aca.transform import radec_to_eci, yagzag_to_radec
+from cxotime import CxoTime
 from kadi import events
 from Quaternion import Quat
 from Ska.engarchive import fetch, fetch_sci
@@ -484,7 +485,7 @@ def _get_obsids_to_update(check_missing=False):
     if check_missing:
         last_tstart = "2007:271:12:00:00"
         kadi_obsids = events.obsids.filter(
-            start=last_tstart, stop__lte=aopcadmd_end_time
+            start=last_tstart, stop__lte=CxoTime(aopcadmd_end_time).date
         )
         with tables.open_file(table_file, "r") as h5:
             tbl_data = h5.root.data[:]
@@ -498,7 +499,7 @@ def _get_obsids_to_update(check_missing=False):
         except Exception:
             last_tstart = "2002:012:12:00:00"
         kadi_obsids = events.obsids.filter(
-            start=last_tstart, stop__lte=aopcadmd_end_time
+            start=last_tstart, stop__lte=CxoTime(aopcadmd_end_time).date
         )
         # Skip the first obsid (as we already have it in the table)
         obsids = [o.obsid for o in kadi_obsids][1:]

--- a/mica/stats/update_acq_stats.py
+++ b/mica/stats/update_acq_stats.py
@@ -763,13 +763,6 @@ def update(opt):
     else:
         obsids = _get_obsids_to_update(check_missing=opt.check_missing)
     for obsid in obsids:
-        import time
-
-        t = time.localtime()
-        # Don't run during kadi update
-        if t.tm_hour == 7:
-            logger.info("Sleeping")
-            time.sleep(3720)
         logger.info("Processing obsid {}".format(obsid))
         try:
             obsid_info, acq_stats, star_info, catalog, temp = calc_stats(obsid)

--- a/mica/stats/update_guide_stats.py
+++ b/mica/stats/update_guide_stats.py
@@ -13,6 +13,7 @@ from astropy.table import Table
 from Chandra.Time import DateTime
 from chandra_aca import dark_model
 from chandra_aca.transform import radec_to_eci
+from cxotime import CxoTime
 from kadi import events
 from Quaternion import Quat
 from Ska.engarchive import fetch, fetch_sci
@@ -417,7 +418,9 @@ def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop
 
     if check_missing:
         last_tstart = start if start is not None else "2007:271:12:00:00"
-        kadi_obsids = events.obsids.filter(start=last_tstart, stop__lte=stop)
+        kadi_obsids = events.obsids.filter(
+            start=last_tstart, stop__lte=CxoTime(stop).date
+        )
         with tables.open_file(table_file, "r") as h5:
             tbl_data = h5.root.data[:]
         # get all obsids that aren't already in tbl
@@ -431,7 +434,9 @@ def _get_obsids_to_update(check_missing=False, table_file=None, start=None, stop
                 ]
         except Exception:
             last_tstart = start if start is not None else "2002:012:12:00:00"
-        kadi_obsids = events.obsids.filter(start=last_tstart, stop__lte=stop)
+        kadi_obsids = events.obsids.filter(
+            start=last_tstart, stop__lte=CxoTime(stop).date
+        )
         # Skip the first obsid (as we already have it in the table)
         obsids = [o.obsid for o in kadi_obsids][1:]
     return obsids


### PR DESCRIPTION
## Description

Fix bug in acq/guide stats processing range

Also removes some old code that was intended to pause acquisition statistics if run during the hour that the kadi update process was supposed to run.  Now that code makes no sense as kadi update runs every ten minutes.

<!--If this fixes an issue then fill this, otherwise DELETE the line below -->
This PR fixes a bug I introduced in https://github.com/sot/mica/pull/318 where I assumed that when using an event filter that the keyword arg to stop__lte could be basically CxoTimeLike.   That's not true.  It looks like the filter will work if supplied a string or object, but doesn't work if given Chandra seconds.  

```
In [2]: obsids1 = events.obsids.filter(start="2025:104", stop__lte=CxoTime("2025:105").secs)
   ...: obsids1[len(obsids1) - 1]
Out[2]: <Obsid: start=2025:111:07:41:08.907 dur=5720 obsid=42463>

In [3]: obsids2 = events.obsids.filter(start="2025:104", stop__lte="2025:105")
   ...: obsids2[len(obsids2) - 1]
Out[3]: <Obsid: start=2025:104:19:47:55.220 dur=14879 obsid=27993>

In [4]: obsids3 = events.obsids.filter(start="2025:104", stop__lte=CxoTime("2025:105"))
   ...: obsids3[len(obsids3) - 1]
Out[4]: <Obsid: start=2025:104:19:47:55.220 dur=14879 obsid=27993>

In [5]: obsids4 = events.obsids.filter(start="2025:104", stop__lte=CxoTime("2025:105").date)
   ...: obsids4[len(obsids4) - 1]
Out[5]: <Obsid: start=2025:104:19:47:55.220 dur=14879 obsid=27993>

```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
================================================= 1 passed in 9.30s ==================================================
(ska3-latest) jeanconn-fido> git rev-parse HEAD
62901d156b3d3e7511938f6b1673eac1ec899d7c
(ska3-latest) jeanconn-fido> pytest
================================================ test session starts =================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 113 items                                                                                                  

mica/archive/tests/test_aca_dark_cal.py ..................                                                     [ 15%]
mica/archive/tests/test_aca_hdr3.py ..                                                                         [ 17%]
mica/archive/tests/test_aca_l0.py .....                                                                        [ 22%]
mica/archive/tests/test_asp_l1.py .......                                                                      [ 28%]
mica/archive/tests/test_cda.py ..............................................                                  [ 69%]
mica/archive/tests/test_obspar.py .                                                                            [ 69%]
mica/report/tests/test_report.py ..                                                                            [ 71%]
mica/report/tests/test_write_report.py .                                                                       [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                   [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                         [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                      [ 92%]
mica/vv/tests/test_vv.py .........                                                                             [100%]

==================================================warnings summary ==================================================
mica/mica/archive/tests/test_asp_l1.py::test_update_l1_archive
  /fido.real/miniforge3/envs/ska3-latest/lib/python3.12/pty.py:95: DeprecationWarning: This process (pid=922524) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/archive/tests/test_cda.py::test_get_proposal_abstract
mica/mica/report/tests/test_write_report.py::test_write_reports
mica/mica/report/tests/test_write_report.py::test_write_reports
  /fido.real/miniforge3/envs/ska3-latest/lib/python3.12/site-packages/bs4/builder/_lxml.py:124: DeprecationWarning: The 'strip_cdata' option of HTMLParser() has never done anything and will eventually be removed.
    parser = parser(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
==================================== 113 passed, 5 warnings in 551.31s (0:09:11)
```

Independent check of unit tests by [REVIEWER NAME]
- [ ] [PLATFORM]:

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
No functional testing.

I have not tested removing the code that added the 3720 second wait.  I think this is fine by inspection.