### PR TITLE
fix archive.cds.get_proposal_abstract

### DIFF
--- a/mica/archive/cda/services.py
+++ b/mica/archive/cda/services.py
@@ -267,6 +267,7 @@ def get_proposal_abstract(obsid=None, propnum=None, timeout=60):
 
     html = _get_cda_service_text("prop_abstract", timeout=timeout, **params)
     text = html_to_text(html)
+    text += "\nTEXT_END:"
 
     # Return value is a text string with these section header lines. Use them
     # to split the text into sections.
@@ -275,7 +276,7 @@ def get_proposal_abstract(obsid=None, propnum=None, timeout=60):
         "Proposal Number",
         "Principal Investigator",
         "Abstract",
-        "",
+        "TEXT_END",
     ]
     out = {}
     for delim0, delim1 in zip(delims[:-1], delims[1:]):

--- a/mica/archive/tests/test_cda.py
+++ b/mica/archive/tests/test_cda.py
@@ -405,7 +405,8 @@ def test_get_proposal_abstract():
             "ALMA. Chandra resolution & sensitivity enables the study of "
             "large scale phenomena: (1) influence of the surrounding "
             "environment; (2) interaction between galaxies; (3) influence of "
-            "groups and clusters"
+            "groups and clusters: (4) BH growth and census; (5) star formation "
+            "and stellar populations; (6) feedback from starbursts and AGNs."
         ),
         "principal_investigator": "Martin Elvis",
         "proposal_number": "08900073",


### PR DESCRIPTION
## Description

This PR fixes `archive.cds.get_proposal_abstract`. The current implementation of `archive.cds.get_proposal_abstract` fails if the abstract does not have any colon, and it truncates the abstract at **last** first colon it finds. The unit test was actually comparing to a truncated abstract, so the test itself was wrong.

This returns information with no abstract and gives the warning `failed to find Abstract in result`:
```
get_proposal_abstract(29944)
```

and this returns a truncated abstract:
```
In [38]: get_proposal_abstract(30454)
Out[38]: 
{'proposal_title': 'A hot shell bounding a young, multiphase, jet-driven outflow in a nearby galaxy',
 'proposal_number': '26700420',
 'principal_investigator': 'Grant Tremblay',
 'abstract': 'We propose a 200 ksec HRC-I observation of a stunning potential discovery made as part of the CARS survey'}
```

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [ ] No unit tests
- [x] Mac
- [ ] Linux
- [ ] Windows

```
(ska3-flight) ~/SAO/git/mica get-abstract $ git rev-parse HEAD
db768f97f82fd7d8ca0c4ec67e3898cb7096643a
(ska3-flight) ~/SAO/git/mica get-abstract $ pytest mica
===================================================================== test session starts =====================================================================
platform darwin -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /Users/javierg/SAO/git
configfile: pytest.ini
plugins: anyio-4.7.0, timeout-2.3.1
collected 113 items                                                                                                                                           

mica/archive/tests/test_aca_dark_cal.py ..................                                                                                              [ 15%]
mica/archive/tests/test_aca_hdr3.py ..                                                                                                                  [ 17%]
mica/archive/tests/test_aca_l0.py ...ss                                                                                                                 [ 22%]
mica/archive/tests/test_asp_l1.py sssssss                                                                                                               [ 28%]
mica/archive/tests/test_cda.py ..............................................                                                                           [ 69%]
mica/archive/tests/test_obspar.py .                                                                                                                     [ 69%]
mica/report/tests/test_report.py ss                                                                                                                     [ 71%]
mica/report/tests/test_write_report.py s                                                                                                                [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                                                            [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                                                                  [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                                                               [ 92%]
mica/vv/tests/test_vv.py sssssssss                                                                                                                      [100%]

=============================================================== 92 passed, 21 skipped in 22.52s ===============================================================

```

Independent check of unit tests by Jean
- [x] Linux
```
(ska3-latest) jeanconn-fido> git rev-parse HEAD
db768f97f82fd7d8ca0c4ec67e3898cb7096643a
(ska3-latest) jeanconn-fido> pytest
=================================================== test session starts ====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 113 items                                                                                                        

mica/archive/tests/test_aca_dark_cal.py ..................                                                           [ 15%]
mica/archive/tests/test_aca_hdr3.py ..                                                                               [ 17%]
mica/archive/tests/test_aca_l0.py .....                                                                              [ 22%]
mica/archive/tests/test_asp_l1.py .....F.                                                                            [ 28%]
mica/archive/tests/test_cda.py ..............................................                                        [ 69%]
mica/archive/tests/test_obspar.py .                                                                                  [ 69%]
mica/report/tests/test_report.py ..                                                                                  [ 71%]
mica/report/tests/test_write_report.py .                                                                             [ 72%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                         [ 85%]
mica/stats/tests/test_acq_stats.py ...                                                                               [ 88%]
mica/stats/tests/test_guide_stats.py ....                                                                            [ 92%]
mica/vv/tests/test_vv.py .........                                                                                   [100%]

========================================================= FAILURES
...
FAILED mica/archive/tests/test_asp_l1.py::test_update_l1_archive - pexpect.exceptions.EOF: End Of File (EOF). Exception style platform.
...
(ska3-latest) jeanconn-fido> source /fido.real/miniforge3/envs/ska3-latest/bin/ska_envs.sh
(ska3-latest) jeanconn-fido> pytest --lf
=================================================== test session starts ====================================================
platform linux -- Python 3.12.8, pytest-8.3.4, pluggy-1.5.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: timeout-2.3.1, anyio-4.7.0
collected 1 item                                                                                                           
run-last-failure: rerun previous 1 failure (skipped 11 files)

mica/archive/tests/test_asp_l1.py .                                                                                  [100%]

==================================================== 1 passed in 12.33s
```

### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
You can verify the statements in the description manually:
```
In [1]: from mica.archive.cda import get_ocat_web, get_proposal_abstract

In [2]: get_proposal_abstract(29944)["abstract"]
Out[2]: 'We propose Chandra observations of four QSOs at z>2, exhibiting bright (>10mJy) extended radio emissions several arcseconds from the core, aligned with pc-scale radio jets on VLBI scales. Current models suggest that, at these redshifts, the Inverse Compton interaction between electrons in the jets and the CMB photons should result in a strong X-ray emission in correspondence with the observed radio jets. To test this prediction, we ask for short snapshot observations of three objects, along with a deep characterisation of the properties of a fourth QS, which already displays an X-ray emission aligned with its radio jets. Through the observation of this carefully selected sample we aim at significantly increasing the dataset of high-redshift extended jets with X-ray observations.'

In [3]: get_proposal_abstract(30454)["abstract"]
Out[3]: 'We propose a 200 ksec HRC-I observation of a stunning potential discovery made as part of the CARS survey: an expanding shell of hot gas draped around the leading edge of a 1,000 km/s, highly multiphase, and young jet-driven outflow in a nearby galaxy. Last year, the HRC-I detected 10 X-ray counts in a semicircular arc apparently draped around the outer rim of this outflow (mapped with MUSE and ALMA). While not statistically significant enough to claim a discovery, the morphology and alignment of the arc is too coincidental to ignore. We request a deeper follow-up observation with the HRC-I (due to its sharper PSF and improved soft-end sensitivity relative to ACIS) to confirm this potentially spectacular discovery.'

```
