### PR TITLE
Support decom of the 32-bit HDR3 quadrant offsets

### DIFF
--- a/mica/archive/aca_hdr3.py
+++ b/mica/archive/aca_hdr3.py
@@ -129,12 +129,16 @@ def quad_offset_from_bytes(
     Parameters
     ----------
     bytes_list : list of np.ndarray[np.uint8]
-        List of byte arrays representing the quadrant offset values.
+        List of byte arrays representing the quadrant offset values. List must be either
+        two or four arrays, each of the same length, representing the bytes to combine
+        for each offset value. The byte arrays should be ordered from most significant
+        byte to least significant byte.
 
     Returns
     -------
-    np.ndarray[np.float64]
-        Array of computed quadrant offset values.
+    np.ndarray[np.uint16] | np.ndarray[np.float64]
+        Array of computed quadrant offset values, uint16 for two byte input, float64 for
+        four byte input.
     """
     m = len(bytes_list)
     # Make a mxN array, then transpose to Nxm, then flatten to mN, then copy to

--- a/mica/archive/aca_hdr3.py
+++ b/mica/archive/aca_hdr3.py
@@ -40,6 +40,10 @@ def _fuzzy_join_times(
     idx_msb : np.ndarray
         Indices into ``times_msb`` for each matched pair.
     """
+    if len(times_msb) == 0 or len(times_lsb) == 0:
+        empty = np.array([], dtype=np.int64)
+        return empty, empty
+
     idx_lsb = np.searchsorted(times_lsb, times_msb, side="left")
     idx_lsb = np.clip(idx_lsb, 0, len(times_lsb) - 1)
     # Check if the previous candidate is closer
@@ -139,11 +143,14 @@ def quad_offset_from_bytes(
 
     # 16- or 32-bit readout offset values need this magic formula from M. Baski (see
     # PEA sampled background patch notes).
+    if m not in (2, 4):
+        raise ValueError(f"Expected 2 or 4 bytes, got {m}")
+
     uints = bytes8.view(f">u{m}")
-    offset = np.uint16(2**15) if m == 2 else np.uint32(2**31)
-    scale = 1 if m == 2 else float(2**16)
-    out = (uints + offset).view(f"<i{m}") / scale
-    return out
+    if m == 2:
+        return (uints + np.uint16(2**15)).view("<i2")
+    else:
+        return (uints + np.uint32(2**31)).view("<i4") / float(2**16)
 
 
 def quad_offset(byte_msids) -> callable:

--- a/mica/archive/aca_hdr3.py
+++ b/mica/archive/aca_hdr3.py
@@ -104,18 +104,19 @@ def bytes_array(byte_msids) -> callable:
     Parameters
     ----------
     byte_msids : list of str
-        List of MSID names representing the byte values to return.
+        List of <m> MSID names representing the byte values to return.
 
     Returns
     -------
     callable
-        Function that takes slot_data and returns an array of raw uint8 byte values.
+        Function that takes slot_data and returns an N x m array of raw uint8 byte
+        values.
     """
 
     def func(slot_data) -> np.ndarray:
         m = len(byte_msids)
         bytes_list = [slot_data[byte_msids[ii]].astype(np.uint8) for ii in range(m)]
-        return bytes_list
+        return np.vstack(bytes_list).transpose()
 
     return func
 
@@ -813,10 +814,10 @@ class MSID(object):
         idx_lsb, idx_msb = _fuzzy_join_times(times_msb, times_lsb)
 
         bytes_list = (
-            msid_msb.vals[0][idx_msb],
-            msid_msb.vals[1][idx_msb],
-            msid_lsb.vals[0][idx_lsb],
-            msid_lsb.vals[1][idx_lsb],
+            msid_msb.vals[:, 0][idx_msb],
+            msid_msb.vals[:, 1][idx_msb],
+            msid_lsb.vals[:, 0][idx_lsb],
+            msid_lsb.vals[:, 1][idx_lsb],
         )
 
         self.times = times_msb[idx_msb]

--- a/mica/archive/aca_hdr3.py
+++ b/mica/archive/aca_hdr3.py
@@ -15,10 +15,48 @@ from scipy.interpolate import interp1d
 
 from mica.archive import aca_l0
 
-TWO_TO_15 = np.uint16(2**15)
+
+def _fuzzy_join_times(
+    times_msb: np.ndarray, times_lsb: np.ndarray, tol: float = 2.1
+) -> tuple[np.ndarray, np.ndarray]:
+    """Return matching index pairs from two monotonically increasing time arrays.
+
+    For each element of ``times_msb``, find the nearest element of ``times_lsb`` and
+    keep the pair only if the time difference is within ``tol`` seconds (inner join).
+
+    Parameters
+    ----------
+    times_msb : np.ndarray
+        Monotonically increasing time array (the "left" side of the join).
+    times_lsb : np.ndarray
+        Monotonically increasing time array (the "right" side of the join).
+    tol : float, optional
+        Maximum allowed time difference in seconds for a match. Default is 2.1.
+
+    Returns
+    -------
+    idx_lsb : np.ndarray
+        Indices into ``times_lsb`` for each matched pair.
+    idx_msb : np.ndarray
+        Indices into ``times_msb`` for each matched pair.
+    """
+    idx_lsb = np.searchsorted(times_lsb, times_msb, side="left")
+    idx_lsb = np.clip(idx_lsb, 0, len(times_lsb) - 1)
+    # Check if the previous candidate is closer
+    idx_lsb_prev = np.maximum(idx_lsb - 1, 0)
+    closer_prev = np.abs(times_lsb[idx_lsb_prev] - times_msb) < np.abs(
+        times_lsb[idx_lsb] - times_msb
+    )
+    idx_lsb = np.where(closer_prev, idx_lsb_prev, idx_lsb)
+
+    # Keep only pairs within the tolerance
+    ok = np.abs(times_lsb[idx_lsb] - times_msb) <= tol
+    idx_msb = np.arange(len(times_msb))[ok]
+    idx_lsb = idx_lsb[ok]
+    return idx_lsb, idx_msb
 
 
-def two_byte_sum(byte_msids, scale=1, as_readout_offset=False) -> callable:
+def two_byte_sum(byte_msids, scale=1) -> callable:
     """
     Create a function to combine two bytes into a 16-bit signed integer.
 
@@ -28,8 +66,6 @@ def two_byte_sum(byte_msids, scale=1, as_readout_offset=False) -> callable:
         List of two MSID names representing the byte values to combine.
     scale : float, optional
         Scale factor to apply to the result. Default is 1.
-    as_readout_offset : bool, optional
-        If True, apply special readout offset formula. Default is False.
 
     Returns
     -------
@@ -48,15 +84,93 @@ def two_byte_sum(byte_msids, scale=1, as_readout_offset=False) -> callable:
         bytes8_2xN = np.vstack([bytes0, bytes1], dtype=np.uint8)
         bytes8 = bytes8_2xN.transpose().flatten().copy()
 
-        if as_readout_offset:
-            # 16-bit readout offset values need this magic formula from M. Baski (see
-            # PEA sampled background patch notes). Note that scale is ignored here.
-            uints16 = bytes8.view(">u2")
-            out = (uints16 + TWO_TO_15).view("<i2")
-        else:
-            # Now view the 2N bytes as N 16-bit signed integers.
-            ints16 = bytes8.view(">i2")
-            out = ints16 * scale
+        # Now view the 2N bytes as N 16-bit signed integers.
+        ints16 = bytes8.view(">i2")
+        out = ints16 * scale
+
+        return out
+
+    return func
+
+
+def bytes_array(byte_msids) -> callable:
+    """
+    Create a function to return raw uint8 byte values in an array.
+
+    Parameters
+    ----------
+    byte_msids : list of str
+        List of MSID names representing the byte values to return.
+
+    Returns
+    -------
+    callable
+        Function that takes slot_data and returns an array of raw uint8 byte values.
+    """
+
+    def func(slot_data) -> np.ndarray:
+        m = len(byte_msids)
+        bytes_list = [slot_data[byte_msids[ii]].astype(np.uint8) for ii in range(m)]
+        return bytes_list
+
+    return func
+
+
+def quad_offset_from_bytes(
+    bytes_list: list[np.ndarray[np.uint8]],
+) -> np.ndarray[np.float64]:
+    """Compute quadrant offset values from a list of byte arrays.
+
+    Parameters
+    ----------
+    bytes_list : list of np.ndarray[np.uint8]
+        List of byte arrays representing the quadrant offset values.
+
+    Returns
+    -------
+    np.ndarray[np.float64]
+        Array of computed quadrant offset values.
+    """
+    m = len(bytes_list)
+    # Make a mxN array, then transpose to Nxm, then flatten to mN, then copy to
+    # get values continous in memory.
+    bytes8_mxN = np.vstack(bytes_list, dtype=np.uint8)
+    bytes8 = bytes8_mxN.transpose().flatten().copy()
+
+    # 16- or 32-bit readout offset values need this magic formula from M. Baski (see
+    # PEA sampled background patch notes).
+    uints = bytes8.view(f">u{m}")
+    offset = np.uint16(2**15) if m == 2 else np.uint32(2**31)
+    scale = 1 if m == 2 else float(2**16)
+    out = (uints + offset).view(f"<i{m}") / scale
+    return out
+
+
+def quad_offset(byte_msids) -> callable:
+    """
+    Create a function to combine two or four bytes into a quadrant offset.
+
+    Parameters
+    ----------
+    byte_msids : list of str
+        List of two or four MSID names representing the byte values to combine.
+
+    Returns
+    -------
+    callable
+        Function that takes slot_data and returns quadrant offset values. The offset
+        values are 16-bit signed integers for two byte MSIDs, and 64-bit floats for four
+        byte MSIDs, with the appropriate scaling applied for readout offsets.
+    """
+
+    def func(slot_data) -> np.ndarray:
+        # For each pair bytes0[i], bytes1[i], return the 16-bit signed integer
+        # corresponding to those two bytes. The input bytes are unsigned.
+        m = len(byte_msids)
+        if m not in (2, 4):
+            raise ValueError(f"Expected 2 or 4 byte MSIDs, got {m}")
+        bytes_list = [slot_data[byte_msids[ii]].astype(np.uint8) for ii in range(m)]
+        out = quad_offset_from_bytes(bytes_list)
 
         return out
 
@@ -351,7 +465,7 @@ The science header pulse period, as measured by the PEA; 1 LSB = 2 microseconds
     "372": {
         "desc": "16-bit zero offset for pixels from CCD quad A",
         "msid": "zero_off16_quad_a",
-        "value": two_byte_sum(["HD3TLM72", "HD3TLM73"], as_readout_offset=True),
+        "value": quad_offset(["HD3TLM72", "HD3TLM73"]),
         "longdesc": """
 A 16-bit zero offset for pixels read from CCD quadrant A; 1 LSB = 1 A/D
 converter count (nominally 5 electrons)
@@ -360,7 +474,7 @@ converter count (nominally 5 electrons)
     "374": {
         "desc": "16-bit zero offset for pixels from CCD quad B",
         "msid": "zero_off16_quad_b",
-        "value": two_byte_sum(["HD3TLM74", "HD3TLM75"], as_readout_offset=True),
+        "value": quad_offset(["HD3TLM74", "HD3TLM75"]),
         "longdesc": """
 A 16-bit zero offset for pixels read from CCD quadrant B; 1 LSB = 1 A/D
 converter count (nominally 5 electrons)
@@ -369,7 +483,7 @@ converter count (nominally 5 electrons)
     "376": {
         "desc": "16-bit zero offset for pixels from CCD quad C",
         "msid": "zero_off16_quad_c",
-        "value": two_byte_sum(["HD3TLM76", "HD3TLM77"], as_readout_offset=True),
+        "value": quad_offset(["HD3TLM76", "HD3TLM77"]),
         "longdesc": """
 A 16-bit zero offset for pixels read from CCD quadrant C; 1 LSB = 1 A/D
 converter count (nominally 5 electrons)
@@ -378,7 +492,7 @@ converter count (nominally 5 electrons)
     "462": {
         "desc": "16-bit zero offset for pixels from CCD quad D",
         "msid": "zero_off16_quad_d",
-        "value": two_byte_sum(["HD3TLM62", "HD3TLM63"], as_readout_offset=True),
+        "value": quad_offset(["HD3TLM62", "HD3TLM63"]),
         "longdesc": """
 A 16-bit zero offset for pixels read from CCD quadrant D; 1 LSB = 1 A/D
 converter count (nominally 5 electrons)
@@ -387,6 +501,7 @@ converter count (nominally 5 electrons)
     "464": {
         "desc": "32-bit zero offset for pixels from CCD quad A",
         "msid": "zero_off32_quad_a",
+        "value": quad_offset(["HD3TLM64", "HD3TLM65", "HD3TLM66", "HD3TLM67"]),
         "longdesc": """
 A 32-bit zero offset for pixels read from CCD quadrant A; 1 LSB = 2^-16
 A/D converter counts
@@ -396,6 +511,7 @@ A/D converter counts
     "472": {
         "desc": "32-bit zero offset for pixels from CCD quad B",
         "msid": "zero_off32_quad_b",
+        "value": quad_offset(["HD3TLM72", "HD3TLM73", "HD3TLM74", "HD3TLM75"]),
         "longdesc": """
 A 32-bit zero offset for pixels read from CCD quadrant B; 1 LSB = 2^-16
 A/D converter counts
@@ -404,16 +520,26 @@ A/D converter counts
     },
     "476": {
         "desc": "32-bit zero offset for pixels from CCD quad C",
-        "msid": "zero_off32_quad_c",
+        "msid": "zero_off32_quad_c_msb",
+        "value": bytes_array(["HD3TLM76", "HD3TLM77"]),
         "longdesc": """
-A 32-bit zero offset for pixels read from CCD quadrant C; 1 LSB = 2^-16
-A/D converter counts
+A 32-bit zero offset for pixels read from CCD quadrant C; most significant two bytes.
 """,
-        "nbytes": 4,
+        "nbytes": 2,
+    },
+    "562": {
+        "desc": "32-bit zero offset for pixels from CCD quad C",
+        "msid": "zero_off32_quad_c_lsb",
+        "value": bytes_array(["HD3TLM62", "HD3TLM63"]),
+        "longdesc": """
+A 32-bit zero offset for pixels read from CCD quadrant C; least significant two bytes.
+""",
+        "nbytes": 2,
     },
     "564": {
         "desc": "32-bit zero offset for pixels from CCD quad D",
         "msid": "zero_off32_quad_d",
+        "value": quad_offset(["HD3TLM64", "HD3TLM65", "HD3TLM66", "HD3TLM67"]),
         "longdesc": """
 A 32-bit zero offset for pixels read from CCD quadrant D; 1 LSB = 2^-16
 A/D converter counts
@@ -616,6 +742,10 @@ class MSID(object):
         self.datestart: str = start.date
         self.datestop: str = stop.date
 
+        if msid == "zero_off32_quad_c":
+            self._get_zero_off32_quad_c()
+            return
+
         slot = MSID_DEFS[self.msid]["slot"]
 
         # Get the 8x8 data with some padding on each end that gets cut later
@@ -658,6 +788,37 @@ class MSID(object):
         self.longdesc = msid_def["longdesc"]
         self.times = slot_data_nomask["TIME"]
         self.hdr3_msid = msid_def
+
+    def _get_zero_off32_quad_c(self):
+        # This is a special case for the zero_off32_quad_c MSID, which is not defined by a
+        # function of the slot data, but instead is defined by the combination of two other
+        # MSIDs that are in different slots. So we need to get those two MSIDs and combine
+        # their data to get this MSID.
+
+        msid_msb = MSID("zero_off32_quad_c_msb", self.datestart, self.datestop)
+        msid_lsb = MSID("zero_off32_quad_c_lsb", self.datestart, self.datestop)
+
+        times_msb = msid_msb.times
+        times_lsb = msid_lsb.times
+
+        # Fuzzy inner join on times with a tolerance of 2.1 sec: for each time in
+        # times1, find the nearest time in times2 via searchsorted.
+        idx_lsb, idx_msb = _fuzzy_join_times(times_msb, times_lsb)
+
+        bytes_list = (
+            msid_msb.vals[0][idx_msb],
+            msid_msb.vals[1][idx_msb],
+            msid_lsb.vals[0][idx_lsb],
+            msid_lsb.vals[1][idx_lsb],
+        )
+
+        self.times = times_msb[idx_msb]
+        self.vals = quad_offset_from_bytes(bytes_list)
+
+        self.desc = "32-bit zero offset for pixels from CCD quadrant C"
+        self.longdesc = """A 32-bit zero offset for pixels read from CCD quadrant C; 1 LSB = 2^-16
+A/D converter counts"""
+        self.hdr3_msid = None
 
     def copy(self):
         from copy import deepcopy

--- a/mica/archive/tests/test_aca_hdr3.py
+++ b/mica/archive/tests/test_aca_hdr3.py
@@ -15,6 +15,10 @@ has_l0_2010_archive = os.path.exists(
     os.path.join(aca_hdr3.aca_l0.CONFIG["data_root"], "2010")
 )
 
+has_l0_2026_archive = os.path.exists(
+    os.path.join(aca_hdr3.aca_l0.CONFIG["data_root"], "2026")
+)
+
 
 @pytest.mark.skipif("not has_l0_2010_archive", reason="Test requires 2010 L0 archive")
 def test_MSIDset():
@@ -64,11 +68,115 @@ def test_two_byte_sum():
     exp = np.array([0, -4081, 4080, -1, 255])
 
     slot_data = Table([bytes0, bytes1], names=["byte0", "byte1"])
-    vals = aca_hdr3.two_byte_sum(["byte0", "byte1"])(slot_data)
+    vals = aca_hdr3.n_byte_sum(["byte0", "byte1"])(slot_data)
     assert vals.dtype == np.int16
     assert np.all(vals == exp)
 
     scale = 2.5
-    vals = aca_hdr3.two_byte_sum(["byte0", "byte1"], scale=scale)(slot_data)
+    vals = aca_hdr3.n_byte_sum(["byte0", "byte1"], scale=scale)(slot_data)
     assert vals.dtype == np.float64
     assert np.all(vals == scale * exp)
+
+
+@pytest.mark.skipif("not has_l0_2026_archive", reason="Test requires 2026 L0 archive")
+def test_quad_offset_16_vs_32():
+    """Test that 16-bit and 32-bit quadrant offsets agree to within 1.0 A/D count.
+
+    The 32-bit value is a higher-resolution version of the same measurement, so the
+    16-bit rounded value (interpolated to the 32-bit timestamps) should differ by less
+    than 1 LSB (1 A/D converter count).
+    """
+    start, stop = "2026:021:02:00:00", "2026:021:03:00:00"
+    for quad in ("a", "b", "c", "d"):
+        dat16 = aca_hdr3.MSID(f"zero_off16_quad_{quad}", start, stop)
+        dat32 = aca_hdr3.MSID(f"zero_off32_quad_{quad}", start, stop)
+
+        # Interpolate the 16-bit values onto the 32-bit timestamps
+        vals16_interp = np.interp(dat32.times, dat16.times, dat16.vals)
+
+        diff = np.abs(vals16_interp - dat32.vals)
+        assert np.all(diff < 1.0), (
+            f"quad {quad}: max diff {diff.max():.4f} exceeds 1.0 A/D count"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for _fuzzy_join_times
+# ---------------------------------------------------------------------------
+
+
+def test_fuzzy_join_times_exact_match():
+    """Identical arrays: every element matches its counterpart exactly."""
+    msb = np.array([10.0, 20.0, 30.0])
+    lsb = np.array([10.0, 20.0, 30.0])
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb)
+    np.testing.assert_array_equal(idx_msb, [0, 1, 2])
+    np.testing.assert_array_equal(idx_lsb, [0, 1, 2])
+
+
+def test_fuzzy_join_times_lsb_slightly_ahead():
+    """LSB times slightly ahead of MSB (searchsorted lands on the correct bin directly)."""
+    msb = np.array([10.0, 20.0, 30.0])
+    lsb = np.array([10.5, 20.5, 30.5])
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb)
+    np.testing.assert_array_equal(idx_msb, [0, 1, 2])
+    np.testing.assert_array_equal(idx_lsb, [0, 1, 2])
+
+
+def test_fuzzy_join_times_lsb_slightly_behind():
+    """LSB times slightly behind MSB (exercises the prev-candidate-is-closer branch)."""
+    msb = np.array([10.0, 20.0, 30.0])
+    lsb = np.array([9.5, 19.5, 29.5])
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb)
+    np.testing.assert_array_equal(idx_msb, [0, 1, 2])
+    np.testing.assert_array_equal(idx_lsb, [0, 1, 2])
+
+
+def test_fuzzy_join_times_gap_excludes_entry():
+    """An MSB entry with no LSB neighbor within tolerance is dropped."""
+    msb = np.array([10.0, 20.0, 30.0])
+    lsb = np.array([10.0, 25.0, 30.0])  # lsb[1] is 5 s from msb[1] > tol
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb)
+    np.testing.assert_array_equal(idx_msb, [0, 2])
+    np.testing.assert_array_equal(idx_lsb, [0, 2])
+
+
+def test_fuzzy_join_times_tolerance_boundary():
+    """Entry at exactly tol is included; entry just over tol is excluded."""
+    msb = np.array([10.0, 20.0, 30.0])
+    lsb = np.array([10.0, 22.0, 33.0])  # msb[1]-lsb[1]=2.0 (in), msb[2]-lsb[2]=3.0 (out)
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb, tol=2.1)
+    np.testing.assert_array_equal(idx_msb, [0, 1])
+    np.testing.assert_array_equal(idx_lsb, [0, 1])
+
+
+def test_fuzzy_join_times_uniform_offset():
+    """MSB and LSB staggered by 1 s; all pairs match with tol=1.1, none with tol=0.9."""
+    msb = np.array([0.0, 2.0, 4.0, 6.0, 8.0])
+    lsb = np.array([1.0, 3.0, 5.0, 7.0, 9.0])
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb, tol=1.1)
+    np.testing.assert_array_equal(idx_msb, [0, 1, 2, 3, 4])
+    np.testing.assert_array_equal(idx_lsb, [0, 1, 2, 3, 4])
+
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb, tol=0.9)
+    assert len(idx_msb) == 0
+    assert len(idx_lsb) == 0
+
+
+def test_fuzzy_join_times_unequal_lengths():
+    """MSB and LSB have different lengths with a gap; multiple MSB can match same LSB.
+
+    msb = [0, 2, 4, 6, 8, 12, 14], lsb = [1, 3, 7.06, 9.04, 10.8, 13.15], tol = 1.1
+      msb[0]=0  -> lsb[0]=1     (diff 1.0)
+      msb[1]=2  -> lsb[1]=3     (diff 1.0)
+      msb[2]=4  -> lsb[1]=3     (diff 1.0; lsb[2]=7.06 is farther)
+      msb[3]=6  -> lsb[2]=7.06  (diff 1.06)
+      msb[4]=8  -> lsb[2]=7.06  (diff 0.94; lsb[3]=9.04 is farther)
+      msb[5]=12 -> lsb[5]=13.15 (diff 1.15 > tol; no match)
+      msb[6]=14 -> lsb[5]=13.15 (diff 0.85)
+    """
+    msb = np.array([0.0, 2.0, 4.0, 6.0, 8.0, 12.0, 14.0])
+    lsb = np.array([1.0, 3.0, 7.06, 9.04, 10.8, 13.15])
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb, tol=1.1)
+    np.testing.assert_array_equal(idx_msb, [0, 1, 2, 3, 4, 6])
+    np.testing.assert_array_equal(idx_lsb, [0, 1, 1, 2, 2, 5])

--- a/mica/archive/tests/test_aca_hdr3.py
+++ b/mica/archive/tests/test_aca_hdr3.py
@@ -61,8 +61,8 @@ def test_MSIDset():
         "zero_off16_quad_d": 10267,
         "zero_off32_quad_a": 10267,
         "zero_off32_quad_b": 10267,
-        "zero_off32_quad_c_lsb": 2,
-        "zero_off32_quad_c_msb": 2,
+        "zero_off32_quad_c_lsb": 10731,
+        "zero_off32_quad_c_msb": 10267,
         "zero_off32_quad_d": 10731,
     }
 

--- a/mica/archive/tests/test_aca_hdr3.py
+++ b/mica/archive/tests/test_aca_hdr3.py
@@ -59,6 +59,11 @@ def test_MSIDset():
         "zero_off16_quad_b": 10710,
         "zero_off16_quad_c": 10710,
         "zero_off16_quad_d": 10267,
+        "zero_off32_quad_a": 10267,
+        "zero_off32_quad_b": 10267,
+        "zero_off32_quad_c_lsb": 2,
+        "zero_off32_quad_c_msb": 2,
+        "zero_off32_quad_d": 10731,
     }
 
 
@@ -68,12 +73,12 @@ def test_two_byte_sum():
     exp = np.array([0, -4081, 4080, -1, 255])
 
     slot_data = Table([bytes0, bytes1], names=["byte0", "byte1"])
-    vals = aca_hdr3.n_byte_sum(["byte0", "byte1"])(slot_data)
+    vals = aca_hdr3.two_byte_sum(["byte0", "byte1"])(slot_data)
     assert vals.dtype == np.int16
     assert np.all(vals == exp)
 
     scale = 2.5
-    vals = aca_hdr3.n_byte_sum(["byte0", "byte1"], scale=scale)(slot_data)
+    vals = aca_hdr3.two_byte_sum(["byte0", "byte1"], scale=scale)(slot_data)
     assert vals.dtype == np.float64
     assert np.all(vals == scale * exp)
 
@@ -144,7 +149,9 @@ def test_fuzzy_join_times_gap_excludes_entry():
 def test_fuzzy_join_times_tolerance_boundary():
     """Entry at exactly tol is included; entry just over tol is excluded."""
     msb = np.array([10.0, 20.0, 30.0])
-    lsb = np.array([10.0, 22.0, 33.0])  # msb[1]-lsb[1]=2.0 (in), msb[2]-lsb[2]=3.0 (out)
+    lsb = np.array(
+        [10.0, 22.0, 33.0]
+    )  # msb[1]-lsb[1]=2.0 (in), msb[2]-lsb[2]=3.0 (out)
     idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb, tol=2.1)
     np.testing.assert_array_equal(idx_msb, [0, 1])
     np.testing.assert_array_equal(idx_lsb, [0, 1])

--- a/mica/archive/tests/test_aca_hdr3.py
+++ b/mica/archive/tests/test_aca_hdr3.py
@@ -152,7 +152,7 @@ def test_fuzzy_join_times_tolerance_boundary():
     lsb = np.array(
         [10.0, 22.0, 33.0]
     )  # msb[1]-lsb[1]=2.0 (in), msb[2]-lsb[2]=3.0 (out)
-    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb, tol=2.1)
+    idx_lsb, idx_msb = aca_hdr3._fuzzy_join_times(msb, lsb, tol=2.0)
     np.testing.assert_array_equal(idx_msb, [0, 1])
     np.testing.assert_array_equal(idx_lsb, [0, 1])
 


### PR DESCRIPTION
## Description

This provides functionality to decom the 32-bit header-3 quadrant readout offsets.

Most of the new code relates to an unfortunate corner case for quadrant C because the 4 bytes are split across two slots. Most of this code and the tests were generated with Claude Sonnet 4.6.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
- [x] Linux
```
ska3-kady$ git rev-parse --short HEAD
273e01a
ska3-kady$ pytest
=========================================== test session starts ===========================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /data/baffin/tom/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 125 items                                                                                       

mica/archive/tests/test_aca_dark_cal.py ..................                                          [ 14%]
mica/archive/tests/test_aca_hdr3.py ..........                                                      [ 22%]
mica/archive/tests/test_aca_l0.py .....                                                             [ 26%]
mica/archive/tests/test_asp_l1.py .......                                                           [ 32%]
mica/archive/tests/test_cda.py ..................................................                   [ 72%]
mica/archive/tests/test_obspar.py .                                                                 [ 72%]
mica/report/tests/test_report.py ss                                                                 [ 74%]
mica/report/tests/test_write_report.py s                                                            [ 75%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                        [ 87%]
mica/stats/tests/test_acq_stats.py ...                                                              [ 89%]
mica/stats/tests/test_guide_stats.py ....                                                           [ 92%]
mica/vv/tests/test_vv.py .........                                                                  [100%]

============================================ warnings summary =============================================
```

Independent check of unit tests by Jean
- [x] Linux
```
jeanconn-kady> pytest
================================================= test session starts ==================================================
platform linux -- Python 3.13.11, pytest-9.0.2, pluggy-1.6.0
rootdir: /proj/sot/ska/jeanproj/git
configfile: pytest.ini
plugins: anyio-4.12.1, timeout-2.4.0
collected 125 items                                                                                                    

mica/archive/tests/test_aca_dark_cal.py ..................                                                       [ 14%]
mica/archive/tests/test_aca_hdr3.py ..........                                                                   [ 22%]
mica/archive/tests/test_aca_l0.py .....                                                                          [ 26%]
mica/archive/tests/test_asp_l1.py .......                                                                        [ 32%]
mica/archive/tests/test_cda.py ..................................................                                [ 72%]
mica/archive/tests/test_obspar.py .                                                                              [ 72%]
mica/report/tests/test_report.py ..                                                                              [ 74%]
mica/report/tests/test_write_report.py .                                                                         [ 75%]
mica/starcheck/tests/test_catalog_fetches.py ...............                                                     [ 87%]
mica/stats/tests/test_acq_stats.py ...                                                                           [ 89%]
mica/stats/tests/test_guide_stats.py ....                                                                        [ 92%]
mica/vv/tests/test_vv.py .........                                                                               [100%]

=================================================== warnings summary ===================================================
mica/mica/archive/tests/test_asp_l1.py::test_update_l1_archive
  /proj/sot/ska3/aca/lib/python3.13/pty.py:95: DeprecationWarning: This process (pid=2859707) is multi-threaded, use of forkpty() may lead to deadlocks in the child.
    pid, fd = os.forkpty()

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
====================================== 125 passed, 1 warning in 378.45s (0:06:18) ======================================
jeanconn-kady> git rev-parse HEAD
19b9ab232af8287ef8cc8cdd0525eb8c43364d80

```
### Functional tests
<!-- Describe and document results of any functional tests, otherwise leave the text below -->
Some functional testing in (unpublished) notebooks related to post-patch pixel telemetry analysis.
